### PR TITLE
[Changed] #6 Use `keycloak.flatland.cloud` with `client_id=fab` for production.

### DIFF
--- a/ts/frontend/src/environments/environment.ts
+++ b/ts/frontend/src/environments/environment.ts
@@ -1,9 +1,9 @@
 import { AuthConfig } from 'angular-oauth2-oidc'
 
 const authConfig: AuthConfig = {
-  issuer: 'http://localhost:8081/realms/netzgrafikeditor',
+  issuer: 'https://keycloak.flatland.cloud/realms/netzgrafikeditor',
   // The ClientId you received from the IAM Team
-  clientId: 'netzgrafikeditor',
+  clientId: 'fab',
   // For production with Angular i18n the language code needs to be included in the redirectUri.
   // In your environment.prod.ts (or similar, but not your environment.ts) replace it with the following line:
   // redirectUri: location.origin + location.pathname.substring(0, location.pathname.indexOf('/', 1) + 1)


### PR DESCRIPTION
## Changes

Use `keycloak.flatland.cloud` with `client_id=fab` for production.

## Related issues

#6 

## Request for Comment
Risk: low
Discussion: low

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Documentation is added in the `docs` folder for relevant behavior changes. If you made important user-facing
  changes, describe them under the `[Unreleased]` tag in `CHANGELOG.md`.
- [ ] Technical guidelines listed in `docs/CONTRIBUTING.md` are followed.
