### PR TITLE
[Fixed] Fix compute worker: env var mismatch for redis. Fix missing file. Add config options for evaluator.

### DIFF
--- a/evaluation/compute_worker/Dockerfile
+++ b/evaluation/compute_worker/Dockerfile
@@ -17,6 +17,7 @@ RUN python -m pip install -U -r requirements.txt
 
 ADD ./evaluator_job.yaml ./evaluator_job.yaml
 ADD ./submission_job.yaml ./submission_job.yaml
+ADD ./retriever_pod.yaml ./retriever_pod.yaml
 
 # configure runner
 USER runner

--- a/evaluation/compute_worker/tasks.py
+++ b/evaluation/compute_worker/tasks.py
@@ -25,6 +25,8 @@ AWS_ENDPOINT_URL = os.environ.get("AWS_ENDPOINT_URL", None)
 AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID", None)
 AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY", None)
 S3_BUCKET = os.environ.get("S3_BUCKET", None)
+S3_UPLOAD_PATH_TEMPLATE = os.getenv("S3_UPLOAD_PATH_TEMPLATE", None)
+S3_UPLOAD_PATH_TEMPLATE_USE_SUBMISSION_ID = os.getenv("S3_UPLOAD_WITH_SUBMISSION_ID", None)
 
 app = Celery(
   broker=os.environ.get('BROKER_URL'),
@@ -66,6 +68,11 @@ def run_evaluation(task_id: str, docker_image: str, submission_image: str, batch
     evaluator_container_definition["env"].append({"name": "AWS_SECRET_ACCESS_KEY", "value": AWS_SECRET_ACCESS_KEY})
   if S3_BUCKET:
     evaluator_container_definition["env"].append({"name": "S3_BUCKET", "value": S3_BUCKET})
+  if S3_UPLOAD_PATH_TEMPLATE:
+    evaluator_container_definition["env"].append({"name": "S3_UPLOAD_PATH_TEMPLATE", "value": S3_UPLOAD_PATH_TEMPLATE})
+  if S3_UPLOAD_PATH_TEMPLATE_USE_SUBMISSION_ID:
+    evaluator_container_definition["env"].append({"name": "S3_UPLOAD_PATH_TEMPLATE_USE_SUBMISSION_ID", "value": S3_UPLOAD_PATH_TEMPLATE_USE_SUBMISSION_ID})
+
   evaluator_container_definition["env"].append({"name": "AICROWD_IS_GRADING", "value": "True"})
 
   evaluator = client.V1Job(metadata=evaluator_definition["metadata"], spec=evaluator_definition["spec"])

--- a/evaluation/compute_worker/tasks.py
+++ b/evaluation/compute_worker/tasks.py
@@ -28,7 +28,7 @@ S3_BUCKET = os.environ.get("S3_BUCKET", None)
 
 app = Celery(
   broker=os.environ.get('BROKER_URL'),
-  backend=REDIS_IP,
+  backend=f"redis://{REDIS_IP}:6379",
 )
 
 


### PR DESCRIPTION
## Changes

* Fix mismatch: `Celery` config expects full URL `redis://host:port` whereas `redis_ip` env variable for Flatland expects only host.
*  Add `retriever_pod.yaml` to compute worker docker container. 
*  Pass through `S3_UPLOAD_PATH_TEMPLATE` and `S3_UPLOAD_PATH_TEMPLATE_USE_SUBMISSION_ID` from compute worker to evaluator.

## Related issues

#40 

## Request for Comment

* Risk: mid (how to improve Q+R?)
* Discussion: mid (how to improve Q+R?)

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [x] Prefix the PR title with one of the labels of [Keep a Changelog](https://keepachangelog.com/):
  - `[Added]`  for new features.
  - `[Changed]` for changes in existing functionality.
  - `[Deprecated]` for soon-to-be removed features.
  - `[Removed]` for now removed features.
  - `[Fixed]` for any bug fixes.
  - `[Security]` in case of vulnerabilities.
- [x] Document changes in this pull request above.
- [ ] Documentation is added in the `docs` folder for relevant behavior changes.
- [ ] Technical guidelines listed in `docs/CONTRIBUTING.md` are followed.
