### PR TITLE
[Changed] #98 Use python 3.13 for compute worker.

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.10", "3.11", "3.12" ]
+        python-version: [ "3.13" ]
     steps:
       - uses: actions/checkout@v4
       - name: Download debug environments

--- a/evaluation/compute_worker/Dockerfile
+++ b/evaluation/compute_worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.13
 
 # This makes output not buffer and return immediately, nice for seeing results in stdout
 ENV PYTHONUNBUFFERED=1

--- a/evaluation/compute_worker/Dockerfile_docker_compose
+++ b/evaluation/compute_worker/Dockerfile_docker_compose
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.13
 
 # This makes output not buffer and return immediately, nice for seeing results in stdout
 ENV PYTHONUNBUFFERED=1

--- a/evaluation/compute_worker/tasks_docker_compose.py
+++ b/evaluation/compute_worker/tasks_docker_compose.py
@@ -35,7 +35,7 @@ def the_task(self, docker_image: str, submission_image: str, **kwargs):
     start_time = time.time()
     logger.info(f"/ start task with task_id={task_id} with docker_image={docker_image} and submission_image={submission_image}")
     assert BENCHMARKING_NETWORK is not None
-    loop = asyncio.new_event_loop()
+    loop = asyncio.get_event_loop()
     evaluator_future = loop.create_future()
     submission_future = loop.create_future()
     evaluator_exec_args = [
@@ -79,8 +79,7 @@ def the_task(self, docker_image: str, submission_image: str, **kwargs):
         "-v", f"{HOST_DIRECTORY}/evaluator/debug-environments/:/tmp/debug-environments/",
         "--network", BENCHMARKING_NETWORK,
         submission_image,
-      ]),
-      loop=loop
+      ])
     )
     loop.run_until_complete(gathered_tasks)
     duration = time.time() - start_time


### PR DESCRIPTION
## Changes

Use Python 3.13 in compute worker and gh action.

## Related issues

Closes #98

## Request for Comment

* Risk: mid
* Discussion: low

## Checklist

- [x] Tests are included for relevant behavior changes.
- [x] Prefix the PR title with one of the labels of [Keep a Changelog](https://keepachangelog.com/):
  - `[Added]`  for new features.
  - `[Changed]` for changes in existing functionality.
  - `[Deprecated]` for soon-to-be removed features.
  - `[Removed]` for now removed features.
  - `[Fixed]` for any bug fixes.
  - `[Security]` in case of vulnerabilities.
- [x] Document changes in this pull request above.
- [ ] Documentation is added in the `docs` folder for relevant behavior changes.
- [ ] Technical guidelines listed in `docs/CONTRIBUTING.md` are followed.
