### PR TITLE
[Added] Add timeout for k8s jobs.

### DIFF
--- a/evaluation/compute_worker/evaluator_job.yaml
+++ b/evaluation/compute_worker/evaluator_job.yaml
@@ -7,6 +7,9 @@ metadata:
 spec:
   template:
     spec:
+      # https://kubernetes.io/docs/concepts/workloads/controllers/job/#handling-pod-and-container-failures
+      # https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy
+      activeDeadlineSeconds: 7200
       restartPolicy: Never
       containers:
         - env:

--- a/evaluation/compute_worker/submission_job.yaml
+++ b/evaluation/compute_worker/submission_job.yaml
@@ -7,6 +7,9 @@ metadata:
 spec:
   template:
     spec:
+      # https://kubernetes.io/docs/concepts/workloads/controllers/job/#handling-pod-and-container-failures
+      # https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy
+      activeDeadlineSeconds: 7200
       restartPolicy: Never
       containers:
         - env:

--- a/evaluation/compute_worker/tasks.py
+++ b/evaluation/compute_worker/tasks.py
@@ -27,6 +27,7 @@ AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY", None)
 S3_BUCKET = os.environ.get("S3_BUCKET", None)
 S3_UPLOAD_PATH_TEMPLATE = os.getenv("S3_UPLOAD_PATH_TEMPLATE", None)
 S3_UPLOAD_PATH_TEMPLATE_USE_SUBMISSION_ID = os.getenv("S3_UPLOAD_PATH_TEMPLATE_USE_SUBMISSION_ID", None)
+ACTIVE_DEADLINE_SECONDS = os.getenv("ACTIVE_DEADLINE_SECONDS", 7200)
 
 app = Celery(
   broker=os.environ.get('BROKER_URL'),
@@ -59,6 +60,7 @@ def run_evaluation(task_id: str, docker_image: str, submission_image: str, batch
   evaluator_container_definition["env"].append({"name": "AICROWD_SUBMISSION_ID", "value": task_id})
   evaluator_container_definition["env"].append({"name": "redis_ip", "value": REDIS_IP})
   evaluator_definition["spec"]["template"]["spec"]["volumes"][2]["persistentVolumeClaim"]["claimName"] = KUBERNETES_PVC
+  evaluator_definition["spec"]["template"]["spec"]["activeDeadlineSeconds"] = ACTIVE_DEADLINE_SECONDS
 
   if AWS_ENDPOINT_URL:
     evaluator_container_definition["env"].append({"name": "AWS_ENDPOINT_URL", "value": AWS_ENDPOINT_URL})
@@ -81,6 +83,7 @@ def run_evaluation(task_id: str, docker_image: str, submission_image: str, batch
   submission_definition = yaml.safe_load(open(Path(__file__).parent / "submission_job.yaml"))
   submission_definition["metadata"]["name"] = f"{submission_definition['metadata']['name']}-{task_id}"
   submission_definition["metadata"]["labels"]["task_id"] = task_id
+  submission_definition["spec"]["template"]["spec"]["activeDeadlineSeconds"] = ACTIVE_DEADLINE_SECONDS
   submission_container_definition = submission_definition["spec"]["template"]["spec"]["containers"][0]
   submission_container_definition["image"] = submission_image
   submission_container_definition["env"].append({"name": "AICROWD_SUBMISSION_ID", "value": task_id})


### PR DESCRIPTION
## Changes

Use `ACTIVE_DEADLINE_SECONDS` to control active deadline of k8s jobs triggered by compute worker.


## Related issues

Closes #69 

## Request for Comment

* Risk: mid
* Discussion: low

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [x] Prefix the PR title with one of the labels of [Keep a Changelog](https://keepachangelog.com/):
  - `[Added]`  for new features.
  - `[Changed]` for changes in existing functionality.
  - `[Deprecated]` for soon-to-be removed features.
  - `[Removed]` for now removed features.
  - `[Fixed]` for any bug fixes.
  - `[Security]` in case of vulnerabilities.
- [x] Document changes in this pull request above.
- [ ] Documentation is added in the `docs` folder for relevant behavior changes.
- [ ] Technical guidelines listed in `docs/CONTRIBUTING.md` are followed.
