### PR TITLE
[Changed] #10 Download environments from S3 in k8s initContainers.

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -21,7 +21,6 @@ Our compute worker is responsible for handling submissions.
 * We set two environment variables:
   * `AICROWD_TESTS_FOLDER` (see https://github.com/flatland-association/flatland-rl/blob/03234e2805d3ed3b8e8343d3e861fd3637e6470d/flatland/evaluators/client.py#L91)
   * `redis_ip` (see https://github.com/flatland-association/flatland-rl/blob/03234e2805d3ed3b8e8343d3e861fd3637e6470d/flatland/evaluators/client.py#L57)
-* Environments are mounted at `/tmp/debug-environments/` (hard-coded location)
 
 ### FAB Benchmark Administrators' User Guide
 
@@ -30,4 +29,4 @@ This describes the default `evaluation/compute_worker` used with a different eva
 * Your evaluator Docker image must ship with an entrypoint, so we can run the container without an entrypoint/command.
 * We set one environment variables:
   * `redis_ip` (see https://github.com/flatland-association/flatland-rl/blob/03234e2805d3ed3b8e8343d3e861fd3637e6470d/flatland/evaluators/client.py#L57)
-* Environments are mounted at `/tmp/debug-environments/` (hard-coded location)
+* Environments are mounted at `/tmp/environments/` (hard-coded location)

--- a/evaluation/compute_worker/evaluator_job.yaml
+++ b/evaluation/compute_worker/evaluator_job.yaml
@@ -14,36 +14,36 @@ spec:
       containers:
         - env:
             - name: AICROWD_TESTS_FOLDER
-              value: /tmp/debug-environments
+              value: /tmp/environments
           image:
           name: f3-evaluator
           pullPolicy: Always
           volumeMounts:
-            - mountPath: /tmp/debug-environments
-              name: debug-environments
+            - mountPath: /tmp/environments
+              name: environments
             - mountPath: /tmp/results
               name: fab-flatland3-results
       initContainers:
         - args:
             - -c
-            - cd /tmp; unzip debug-environments.zip
+            - unzip /tmp/environments.zip -d /tmp/environments
           command:
             - /bin/sh
           image: busybox
           imagePullPolicy: IfNotPresent
           name: startup
           volumeMounts:
-            - mountPath: /tmp/debug-environments.zip
-              name: fab-flatland3-data-vol
-              subPath: debug-environments.zip
-            - mountPath: /tmp/debug-environments
-              name: debug-environments
+            - mountPath: /tmp/environments.zip
+              name: fab-flatland3-evaluator-data-vol
+              subPath: environments.zip
+            - mountPath: /tmp/environments
+              name: environments
       volumes:
         - configMap:
-            name: fab-flatland3-data
-          name: fab-flatland3-data-vol
+            name: fab-flatland3-evaluator-data
+          name: fab-flatland3-evaluator-data-vol
         - emptyDir: { }
-          name: debug-environments
+          name: environments
         - name: fab-flatland3-results
           persistentVolumeClaim:
             claimName:

--- a/evaluation/compute_worker/evaluator_job.yaml
+++ b/evaluation/compute_worker/evaluator_job.yaml
@@ -42,7 +42,6 @@ spec:
               set -x
               find /tmp
               unzip /tmp/environments/environments.zip -d /tmp/environments/
-              mv /tmp/environments/tmptfguzhxe/* /tmp/environments/
               find /tmp
           command:
             - /bin/sh

--- a/evaluation/compute_worker/evaluator_job.yaml
+++ b/evaluation/compute_worker/evaluator_job.yaml
@@ -21,29 +21,37 @@ spec:
           volumeMounts:
             - mountPath: /tmp/environments
               name: environments
-            - mountPath: /tmp/results
-              name: fab-flatland3-results
       initContainers:
+        - image: amazon/aws-cli
+          imagePullPolicy: IfNotPresent
+          name: download-environments
+          env: [ ]
+          command:
+            - aws
+            - s3
+            - cp
+            - s3://fab-data/flatland3/environments.zip
+            - /tmp/environments
+          volumeMounts:
+            - mountPath: /tmp/environments
+              name: environments
         - args:
             - -c
-            - unzip /tmp/environments.zip -d /tmp/environments
+            - |
+              set -e
+              set -x
+              find /tmp
+              unzip /tmp/environments/environments.zip -d /tmp/environments/
+              mv /tmp/environments/tmptfguzhxe/* /tmp/environments/
+              find /tmp
           command:
             - /bin/sh
           image: busybox
           imagePullPolicy: IfNotPresent
-          name: startup
+          name: extract-environments
           volumeMounts:
-            - mountPath: /tmp/environments.zip
-              name: fab-flatland3-evaluator-data-vol
-              subPath: environments.zip
             - mountPath: /tmp/environments
               name: environments
       volumes:
-        - configMap:
-            name: fab-flatland3-evaluator-data
-          name: fab-flatland3-evaluator-data-vol
         - emptyDir: { }
           name: environments
-        - name: fab-flatland3-results
-          persistentVolumeClaim:
-            claimName:

--- a/evaluation/compute_worker/submission_job.yaml
+++ b/evaluation/compute_worker/submission_job.yaml
@@ -42,7 +42,6 @@ spec:
               set -x
               find /tmp
               unzip /tmp/environments/environments.zip -d /tmp/environments/
-              mv /tmp/environments/tmptfguzhxe/* /tmp/environments/
               find /tmp
           command:
             - /bin/sh

--- a/evaluation/compute_worker/submission_job.yaml
+++ b/evaluation/compute_worker/submission_job.yaml
@@ -22,23 +22,37 @@ spec:
             - mountPath: /tmp
               name: environments
       initContainers:
+        - command:
+            - aws
+            - s3
+            - cp
+            - s3://fab-data/flatland3/environments.zip
+            - /tmp/environments
+          env: [ ]
+          image: amazon/aws-cli
+          imagePullPolicy: IfNotPresent
+          name: download-environments
+          volumeMounts:
+            - mountPath: /tmp/environments
+              name: environments
         - args:
             - -c
-            - unzip /tmp/environments.zip -d /tmp/environments
+            - |
+              set -e
+              set -x
+              find /tmp
+              unzip /tmp/environments/environments.zip -d /tmp/environments/
+              mv /tmp/environments/tmptfguzhxe/* /tmp/environments/
+              find /tmp
           command:
             - /bin/sh
           image: busybox
           imagePullPolicy: IfNotPresent
-          name: startup
+          name: extract-environments
           volumeMounts:
-            - mountPath: /tmp/environments.zip
-              name: fab-flatland3-submission-data-vol
-              subPath: environments.zip
             - mountPath: /tmp/environments
               name: environments
       volumes:
-        - configMap:
-            name: fab-flatland3-submission-data
-          name: fab-flatland3-submission-data-vol
         - emptyDir: { }
           name: environments
+

--- a/evaluation/compute_worker/submission_job.yaml
+++ b/evaluation/compute_worker/submission_job.yaml
@@ -20,25 +20,25 @@ spec:
           name: f3-submission
           volumeMounts:
             - mountPath: /tmp
-              name: debug-environments
+              name: environments
       initContainers:
         - args:
             - -c
-            - cd /tmp; unzip debug-environments.zip
+            - unzip /tmp/environments.zip -d /tmp/environments
           command:
             - /bin/sh
           image: busybox
           imagePullPolicy: IfNotPresent
           name: startup
           volumeMounts:
-            - mountPath: /tmp/debug-environments.zip
-              name: fab-flatland3-data-vol
-              subPath: debug-environments.zip
-            - mountPath: /tmp/debug-environments
-              name: debug-environments
+            - mountPath: /tmp/environments.zip
+              name: fab-flatland3-submission-data-vol
+              subPath: environments.zip
+            - mountPath: /tmp/environments
+              name: environments
       volumes:
         - configMap:
-            name: fab-flatland3-data
-          name: fab-flatland3-data-vol
+            name: fab-flatland3-submission-data
+          name: fab-flatland3-submission-data-vol
         - emptyDir: { }
-          name: debug-environments
+          name: environments

--- a/evaluation/compute_worker/tasks.py
+++ b/evaluation/compute_worker/tasks.py
@@ -194,7 +194,7 @@ def main():
   assert ret["f3-evaluator"]["job_status"] == "Complete"
   assert ret["f3-submission"]["job_status"] == "Complete"
   assert ret["f3-evaluator"]["image_id"].startswith("ghcr.io/flatland-association/fab-flatland-evaluator")
-  assert ret["f3-submission"]["image_id"].startswith("ghcr.io/flatland-association/flatland-benchmarks-f3-starterkit:latest")
+  assert ret["f3-submission"]["image_id"].startswith("ghcr.io/flatland-association/flatland-benchmarks-f3-starterkit")
   assert "end evaluator/run.sh" in str(ret["f3-evaluator"]["log"])
   assert "end submission_template/run.sh" in str(ret["f3-submission"]["log"])
   res_df = pd.read_csv(StringIO(ret["f3-evaluator"]["results.csv"]))


### PR DESCRIPTION
## Changes

* Download and extract environments from S3 in k8s init containers.
* Use /tmp/environments for mounting envs (both docker-compose and k8s) because of https://stackoverflow.com/questions/53012798/kubernetes-configmap-size-limitation#53015758


## Related issues

#10 

## Request for Comment

* Risk: mid (manually tested)
* Discussion: low

## Checklist

- [x] Tests are included for relevant behavior changes.
- [x] Prefix the PR title with one of the labels of [Keep a Changelog](https://keepachangelog.com/):
  - `[Added]`  for new features.
  - `[Changed]` for changes in existing functionality.
  - `[Deprecated]` for soon-to-be removed features.
  - `[Removed]` for now removed features.
  - `[Fixed]` for any bug fixes.
  - `[Security]` in case of vulnerabilities.
- [x] Document changes in this pull request above.
- [x] Documentation is added in the `docs` folder for relevant behavior changes.
- [ ] Technical guidelines listed in `docs/CONTRIBUTING.md` are followed.
