### PR TITLE
docs: fix spelling in DEVELOPMENT md

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -25,11 +25,11 @@ The project is configured to lint and format your source code before committing 
 
 > If `lint-staged` fails and **discards** your changes, you can often `git stash pop` them back into existence. Run the `lint` npm script manually beforehand or install the VSCode plugins as described above to limit any surprises.
 
-## Developper notes
+## Developer notes
 
 ### dev.001 - GET list returns previews instead of full resources
 
-API endpoints listing resources - such as GET `/bechmarks` - should only return list of preview (URI + selected fields). The full resources themselves are then fetched in consecutive requests. This enables effective caching on the client side and minimizes transmitted data load.
+API endpoints listing resources - such as GET `/bechnmarks` - should only return list of preview (URI + selected fields). The full resources themselves are then fetched in consecutive requests. This enables effective caching on the client side and minimizes transmitted data load.
 
 2025-01-24, Olivier Stuker
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -29,7 +29,7 @@ The project is configured to lint and format your source code before committing 
 
 ### dev.001 - GET list returns previews instead of full resources
 
-API endpoints listing resources - such as GET `/bechnmarks` - should only return list of preview (URI + selected fields). The full resources themselves are then fetched in consecutive requests. This enables effective caching on the client side and minimizes transmitted data load.
+API endpoints listing resources - such as GET `/benchmarks` - should only return list of preview (URI + selected fields). The full resources themselves are then fetched in consecutive requests. This enables effective caching on the client side and minimizes transmitted data load.
 
 2025-01-24, Olivier Stuker
 


### PR DESCRIPTION

## Changes
- Develo**p**~p~er notes
- GET **bench**marks

<!-- Describe the changes you made. -->

## Related issues

<!--
Link to every issue from the issue tracker (if any) you addressed in this PR.
See [here](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) on how to use keywords to automatically close the issue when someone merges the pull request
-->

## Request for Comment

* Risk: <!-- [low/mid/high] -->
* Discussion: <!-- [low/mid/high] -->

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [x] Prefix the commits with one of the labels of [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).
<!--
The Conventional Commits specification is a lightweight convention on top of commit messages. It provides an easy set of rules for creating an explicit commit history; which makes it easier to write automated tools on top of. This convention dovetails with SemVer, by describing the features, fixes, and breaking changes made in commit messages.

The commit message should be structured as follows:
  <type>[optional scope]: <description>
  
  [optional body]
  
  [optional footer(s)]


1. fix: a commit of the type fix patches a bug in your codebase (this correlates with PATCH in Semantic Versioning).
2. feat: a commit of the type feat introduces a new feature to the codebase (this correlates with MINOR in Semantic Versioning).
3. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.
4. types other than fix: and feat: are allowed, for example @commitlint/config-conventional (based on the Angular convention) recommends 
    - build:
    - chore:
    - ci:
    - docs:
    - style:
    - refactor:
    - perf:
    - test:
5. footers other than BREAKING CHANGE: <description> may be provided and follow a convention similar to git trailer format.
 
-->
- [x] Document changes in this pull request above.
- [ ] Documentation is added in the `docs` folder for relevant behavior changes.
- [x] Technical guidelines listed in `docs/CONTRIBUTING.md` are followed.
