### PR TITLE
chore(backend): refactor interfaces

### DIFF
--- a/ts/common/api-endpoints.ts
+++ b/ts/common/api-endpoints.ts
@@ -23,7 +23,7 @@ interface ApiEndpointVerbs {
   PATCH?: ApiEndpoint
 }
 
-// There is no way in TypeScript to enforce the types of an interfaces'
+// There is no way in TypeScript to enforce the types of an interface's
 // properties a priori - instead, give dev freedom to make mistakes and filter
 // those endpoints that actually match the `path: ApiEndpointVerbs` pattern
 // below (see ApiEndpoints below), otherwise any mistake in the definitions

--- a/ts/common/utility-types.ts
+++ b/ts/common/utility-types.ts
@@ -22,6 +22,13 @@ export type BanEmpty<T> =
   }
 
 /**
+ * Utility type removing all properties with type `never`.
+ */
+export type NoNever<T> = {
+  [K in keyof T as T[K] extends never ? never : K]: T[K]
+}
+
+/**
  * Guard type checking that `T` is not a key of `R`.
  */
 export type NotKeyOf<T, R> = T extends keyof R ? never : T


### PR DESCRIPTION
## Changes

The interface defining the API endpoints now collects all the available http verbs in one endpoint (prior: distinct interface for get endpoints, post endpoints, patch endpoints and so on).

Reasoning:
* less code to write (endpoint route doesn't have to be repeated over and over again)
* the endpoint type definitions is uniform now, which means the more specific ones (e.g. `ApiGetEndpoints`) can be derived automatically from the main definition

## Related issues

Part of #63 

## Request for Comment

* Risk: low - no impact on runtime behavior
* Discussion: low

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Prefix the commits with one of the labels of [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).
<!--
The Conventional Commits specification is a lightweight convention on top of commit messages. It provides an easy set of rules for creating an explicit commit history; which makes it easier to write automated tools on top of. This convention dovetails with SemVer, by describing the features, fixes, and breaking changes made in commit messages.

The commit message should be structured as follows:
  <type>[optional scope]: <description>
  
  [optional body]
  
  [optional footer(s)]


1. fix: a commit of the type fix patches a bug in your codebase (this correlates with PATCH in Semantic Versioning).
2. feat: a commit of the type feat introduces a new feature to the codebase (this correlates with MINOR in Semantic Versioning).
3. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.
4. types other than fix: and feat: are allowed, for example @commitlint/config-conventional (based on the Angular convention) recommends 
    - build:
    - chore:
    - ci:
    - docs:
    - style:
    - refactor:
    - perf:
    - test:
5. footers other than BREAKING CHANGE: <description> may be provided and follow a convention similar to git trailer format.
 
-->
- [ ] Document changes in this pull request above.
- [ ] Documentation is added in the `docs` folder for relevant behavior changes.
- [ ] Technical guidelines listed in `docs/CONTRIBUTING.md` are followed.
