### PR TITLE
refactor: update benchmark_id and test_ids in submission and results …

### DIFF
--- a/ts/backend/src/app/features/controller/results.controller.mts
+++ b/ts/backend/src/app/features/controller/results.controller.mts
@@ -746,7 +746,7 @@ export class ResultsController extends Controller {
       SELECT * FROM submissions WHERE id=${submissionId}
     `
     const [benchmarkDefRow] = await sql.query<BenchmarkDefinitionRow>`
-      SELECT * FROM benchmark_definitions WHERE id=${submissionRow.benchmark_definition_id}
+      SELECT * FROM benchmark_definitions WHERE id=${submissionRow.benchmark_id}
     `
     // load required candidates for referenced fields (used in upcast) and upcast
     const fieldDefCandidates = await sql.query<FieldDefinitionRow>`

--- a/ts/backend/src/app/features/controller/submission.controller.mts
+++ b/ts/backend/src/app/features/controller/submission.controller.mts
@@ -37,7 +37,7 @@ export class SubmissionController extends Controller {
    *              name:
    *                type: string
    *                description: Display name of submission.
-   *              benchmark_definition_id:
+   *              benchmark_id:
    *                type: string
    *                format: uuid
    *                description: ID of benchmark this submission belongs to.
@@ -47,7 +47,7 @@ export class SubmissionController extends Controller {
    *              code_repository:
    *                type: string
    *                description: URL of submission code repository.
-   *              test_definition_ids:
+   *              test_ids:
    *                type: array
    *                items:
    *                  type: string
@@ -91,8 +91,8 @@ export class SubmissionController extends Controller {
           submitted_by,
           submitted_by_username
         ) VALUES (
-          ${req.body.benchmark_definition_id},
-          ${req.body.test_definition_ids},
+          ${req.body.benchmark_id},
+          ${req.body.test_ids},
           ${req.body.name},
           ${req.body.submission_data_url},
           ${req.body.code_repository ?? null},
@@ -110,8 +110,8 @@ export class SubmissionController extends Controller {
     // get tests
     const tests = await sql.query<TestDefinitionRow>`
         SELECT * FROM test_definitions
-        WHERE id=ANY(${req.body.test_definition_ids})
-        LIMIT ${req.body.test_definition_ids!.length}
+        WHERE id=ANY(${req.body.test_ids})
+        LIMIT ${req.body.test_ids!.length}
       `
     // if required (not all OFFLINE), send message with test names to evaluator
     if (tests.some((test) => test.loop !== 'OFFLINE')) {
@@ -124,7 +124,7 @@ export class SubmissionController extends Controller {
       logger.info(`Sending ${payload} to celery.`)
       try {
         // the returned unsettled promise is ignored and continues running (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
-        celery.sendTask(req.body.benchmark_definition_id as string, payload, id)
+        celery.sendTask(req.body.benchmark_id as string, payload, id)
         // request succeeds once connection is checked ready and task sent
         this.respond(req, res, { id }, payload)
       } catch (error) {

--- a/ts/backend/src/app/features/utils/aggregator.mts
+++ b/ts/backend/src/app/features/utils/aggregator.mts
@@ -31,7 +31,7 @@ Leaderboard -  i.e. a list of scored submissions
 └ SubmissionScored[] - scored submissions (scores aggregated at test level and aggregated at benchmark level from tests), a submission refers to exactly one benchmark by definition
   └ TestScored[] - scored tests (aggregated from scenarios)
     └ ScenarioScored[] - scored scenarios
-    
+
 In campaign setting:
 Campaign Overview: list of CampaignItems
 └ CampaignItem -  a benchmark scored by aggregation of the best test score; the best test from all SubmissionScored
@@ -137,7 +137,7 @@ export function upcastSubmissionRow(
   testDefinitionCandidates: TestDefinitionRow[],
   benchmarkDefinitionCandidates: BenchmarkDefinitionRow[],
 ): Submission {
-  const benchmarkDef = benchmarkDefinitionCandidates.find((c) => c.id === row.benchmark_definition_id) ?? null
+  const benchmarkDef = benchmarkDefinitionCandidates.find((c) => c.id === row.benchmark_id) ?? null
   return {
     dir: row.dir,
     id: row.id,
@@ -149,7 +149,7 @@ export function upcastSubmissionRow(
           testDefinitionCandidates,
         )
       : null,
-    test_definitions: row.test_definition_ids.map((id) => {
+    test_definitions: row.test_ids.map((id) => {
       const test = testDefinitionCandidates.find((c) => c.id === id) ?? null
       if (test) {
         return upcastTestDefinitionRow(test, fieldDefinitionCandidates, scenarioDefinitionCandidates)

--- a/ts/backend/test/integration/submission.controller.spec.ts
+++ b/ts/backend/test/integration/submission.controller.spec.ts
@@ -5,8 +5,8 @@ import { ControllerTestAdapter, setupControllerTestEnvironment, testUserJwt } fr
 import { getTestConfig } from './setup.mjs'
 
 const testSubmission: StripLocator<SubmissionRow> = {
-  benchmark_definition_id: '20ccc7c1-034c-4880-8946-bffc3fed1359',
-  test_definition_ids: ['79094281-35ff-484d-a687-cccb228a04a0'],
+  benchmark_id: '20ccc7c1-034c-4880-8946-bffc3fed1359',
+  test_ids: ['79094281-35ff-484d-a687-cccb228a04a0'],
   name: 'test',
   submission_data_url: 'none',
 }

--- a/ts/common/interfaces.ts
+++ b/ts/common/interfaces.ts
@@ -98,8 +98,8 @@ export type SubmissionStatus = 'SUBMITTED' | 'RUNNING' | 'SUCCESS' | 'FAILURE'
 
 export interface SubmissionRow extends Resource<'/submissions/'> {
   id: string
-  benchmark_definition_id: string
-  test_definition_ids: string[]
+  benchmark_id: string
+  test_ids: string[]
   name: string
   description?: string | null
   submission_data_url: string


### PR DESCRIPTION
…controllers.

## Changes

<!-- Describe the changes you made. -->

## Related issues

<!--
Link to every issue from the issue tracker (if any) you addressed in this PR.
See [here](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) on how to use keywords to automatically close the issue when someone merges the pull request
-->

## Request for Comment

* Risk: <!-- [low/mid/high] -->
* Discussion: <!-- [low/mid/high] -->

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Prefix the commits with one of the labels of [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).
<!--
The Conventional Commits specification is a lightweight convention on top of commit messages. It provides an easy set of rules for creating an explicit commit history; which makes it easier to write automated tools on top of. This convention dovetails with SemVer, by describing the features, fixes, and breaking changes made in commit messages.

The commit message should be structured as follows:
  <type>[optional scope]: <description>
  
  [optional body]
  
  [optional footer(s)]


1. fix: a commit of the type fix patches a bug in your codebase (this correlates with PATCH in Semantic Versioning).
2. feat: a commit of the type feat introduces a new feature to the codebase (this correlates with MINOR in Semantic Versioning).
3. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.
4. types other than fix: and feat: are allowed, for example @commitlint/config-conventional (based on the Angular convention) recommends 
    - build:
    - chore:
    - ci:
    - docs:
    - style:
    - refactor:
    - perf:
    - test:
5. footers other than BREAKING CHANGE: <description> may be provided and follow a convention similar to git trailer format.
 
-->
- [ ] Document changes in this pull request above.
- [ ] Documentation is added in the `docs` folder for relevant behavior changes.
- [ ] Technical guidelines listed in `docs/CONTRIBUTING.md` are followed.
