### PR TITLE
feat(frontend): Display submission status

### DIFF
--- a/ts/backend/src/app/features/controller/results.controller.mts
+++ b/ts/backend/src/app/features/controller/results.controller.mts
@@ -123,7 +123,6 @@ export class ResultsController extends Controller {
       // only transmit valid items
       if (leaderboardItem) {
         // transform for transmission
-        // TODO: properly define data format of results for transmission
         leaderboardItems.push({
           submission_id: leaderboardItem.submission.id,
           scorings: leaderboardItem.scorings,

--- a/ts/backend/src/app/features/controller/results.controller.mts
+++ b/ts/backend/src/app/features/controller/results.controller.mts
@@ -116,32 +116,33 @@ export class ResultsController extends Controller {
       return
     }
 
-    // TODO https://github.com/flatland-association/flatland-benchmarks/issues/317 support multiple submission_ids
-    const submissionId = req.params.submission_ids
-    const submissionScored = await this.aggregateSubmissionScore(submissionId)
-    if (!submissionScored) {
-      this.requestError(req, res, { text: 'Score could not be aggregated' })
-      return
-    }
-    // transform for transmission
-    // TODO: properly define data format of results for transmission
-    const result: LeaderboardItem = {
-      submission_id: submissionScored.submission.id,
-      scorings: submissionScored.scorings,
-      test_scorings: submissionScored.tests.map((test) => {
-        return {
-          test_id: test.definition.id,
-          scorings: test.scorings,
-          scenario_scorings: test.scenarios.map((scenario) => {
+    const submissionIds = req.params.submission_ids.split(',')
+    const leaderboardItems: LeaderboardItem[] = []
+    for (const submissionId of submissionIds) {
+      const leaderboardItem = await this.aggregateSubmissionScore(submissionId)
+      // only transmit valid items
+      if (leaderboardItem) {
+        // transform for transmission
+        // TODO: properly define data format of results for transmission
+        leaderboardItems.push({
+          submission_id: leaderboardItem.submission.id,
+          scorings: leaderboardItem.scorings,
+          test_scorings: leaderboardItem.tests.map((test) => {
             return {
-              scenario_id: scenario.definition.id,
-              scorings: scenario.scorings,
-            }
+              test_id: test.definition.id,
+              scorings: test.scorings,
+              scenario_scorings: test.scenarios.map((scenario) => {
+                return {
+                  scenario_id: scenario.definition.id,
+                  scorings: scenario.scorings,
+                } satisfies ScenarioScored
+              }),
+            } satisfies TestScored
           }),
-        }
-      }),
+        })
+      }
     }
-    this.respond(req, res, [result])
+    this.respond(req, res, leaderboardItems)
   }
 
   /**


### PR DESCRIPTION
## Changes

- Fix submission results controller not handling comma-separated ids
- Added status display on my-submissions overview
- Changed date format on my-submissions overview

## Related issues

Closes #257
Opens #320 

## Request for Comment

* Risk:  low
* Discussion: low

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Prefix the commits with one of the labels of [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).
<!--
The Conventional Commits specification is a lightweight convention on top of commit messages. It provides an easy set of rules for creating an explicit commit history; which makes it easier to write automated tools on top of. This convention dovetails with SemVer, by describing the features, fixes, and breaking changes made in commit messages.

The commit message should be structured as follows:
  <type>[optional scope]: <description>
  
  [optional body]
  
  [optional footer(s)]


1. fix: a commit of the type fix patches a bug in your codebase (this correlates with PATCH in Semantic Versioning).
2. feat: a commit of the type feat introduces a new feature to the codebase (this correlates with MINOR in Semantic Versioning).
3. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.
4. types other than fix: and feat: are allowed, for example @commitlint/config-conventional (based on the Angular convention) recommends 
    - build:
    - chore:
    - ci:
    - docs:
    - style:
    - refactor:
    - perf:
    - test:
5. footers other than BREAKING CHANGE: <description> may be provided and follow a convention similar to git trailer format.
 
-->
- [ ] Document changes in this pull request above.
- [ ] Documentation is added in the `docs` folder for relevant behavior changes.
- [ ] Technical guidelines listed in `docs/CONTRIBUTING.md` are followed.
