### PR TITLE
feat(frontend): Manual results upload

### DIFF
--- a/ts/backend/src/app/features/controller/field.controller.mts
+++ b/ts/backend/src/app/features/controller/field.controller.mts
@@ -1,0 +1,70 @@
+import { appendDir } from '@common/endpoint-utils.js'
+import { FieldDefinitionRow } from '@common/interfaces.js'
+import { StripDir } from '@common/utility-types.js'
+import { configuration } from '../config/config.mjs'
+import { SqlService } from '../services/sql-service.mjs'
+import { Controller, GetHandler } from './controller.mjs'
+
+export class FieldController extends Controller {
+  constructor(config: configuration) {
+    super(config)
+
+    this.attachGet('/definitions/fields/:field_ids', this.getFielddById)
+  }
+
+  /**
+   * @swagger
+   * /definitions/fields/{field_ids}:
+   *  get:
+   *    description: Returns fields with ID in `ids`.
+   *    security:
+   *      - oauth2: [user]
+   *    parameters:
+   *      - in: path
+   *        name: field_ids
+   *        description: Comma-separated list of IDs.
+   *        required: true
+   *        schema:
+   *          type: array
+   *          items:
+   *            type: string
+   *            format: uuid
+   *    responses:
+   *      200:
+   *        description: Requested fields.
+   *        content:
+   *          application/json:
+   *            schema:
+   *              allOf:
+   *                - $ref: "#/components/schemas/ApiResponse"
+   *                - type: object
+   *                  properties:
+   *                    body:
+   *                      type: array
+   *                      items:
+   *                        type: object
+   *                        properties:
+   *                          dir:
+   *                            type: string
+   *                          id:
+   *                            type: string
+   *                            format: uuid
+   *                          key:
+   *                            type: string
+   *                          description:
+   *                            type: string
+   */
+  getFielddById: GetHandler<'/definitions/fields/:field_ids'> = async (req, res) => {
+    const ids = req.params.field_ids.split(',')
+    const sql = SqlService.getInstance()
+    // id=ANY - dev.003
+    const rows = await sql.query<StripDir<FieldDefinitionRow>>`
+        SELECT * FROM field_definitions
+        WHERE id=ANY(${ids})
+        LIMIT ${ids.length}
+      `
+    const fields = appendDir('/definitions/fields/', rows)
+    // return array - dev.002
+    this.respond(req, res, fields)
+  }
+}

--- a/ts/backend/src/app/features/server/server.mts
+++ b/ts/backend/src/app/features/server/server.mts
@@ -8,6 +8,7 @@ import { configuration } from '../config/config.mjs'
 import { BenchmarkGroupController } from '../controller/benchmark-group.controller.mjs'
 import { BenchmarkController } from '../controller/benchmark.controller.mjs'
 import { DebugController } from '../controller/debug.controller.mjs'
+import { FieldController } from '../controller/field.controller.mjs'
 import { HealthController } from '../controller/health.controller.mjs'
 import { ResultsController } from '../controller/results.controller.mjs'
 import { ScenarioController } from '../controller/scenario.controller.mjs'
@@ -39,6 +40,7 @@ export class Server {
     this.app.use(new BenchmarkGroupController(this.config).router)
     this.app.use(new TestController(this.config).router)
     this.app.use(new ScenarioController(this.config).router)
+    this.app.use(new FieldController(this.config).router)
     this.app.use(new SubmissionController(this.config).router)
     this.app.use(new ResultsController(this.config).router)
 

--- a/ts/backend/test/integration/field.controller.spec.ts
+++ b/ts/backend/test/integration/field.controller.spec.ts
@@ -1,0 +1,22 @@
+import { FieldController } from '../../src/app/features/controller/field.controller.mjs'
+import { ControllerTestAdapter, setupControllerTestEnvironment } from '../controller.test-adapter.mjs'
+import { getTestConfig } from './setup.mjs'
+
+describe.sequential('Field controller', () => {
+  let controller: ControllerTestAdapter
+
+  beforeAll(async () => {
+    const testConfig = await getTestConfig()
+    setupControllerTestEnvironment(testConfig)
+    controller = new ControllerTestAdapter(FieldController, testConfig)
+  })
+
+  test('should return scenario by id', async () => {
+    const res = await controller.testGet('/definitions/fields/:field_ids', {
+      params: { field_ids: '9d6da5c3-1cfc-4f87-8b57-607a0ce02b2b' },
+    })
+    expect(res.status).toBe(200)
+    expect(res.body).toBeApiResponse()
+    expect(res.body.body?.at(0)).toBeTruthy()
+  })
+})

--- a/ts/common/api-endpoints.ts
+++ b/ts/common/api-endpoints.ts
@@ -5,6 +5,7 @@ import {
   BenchmarkGroupDefinitionRow,
   CampaignItemOverview,
   CampaignOverview,
+  FieldDefinitionRow,
   Leaderboard,
   LeaderboardItem,
   PostTestResultsBody,
@@ -84,6 +85,9 @@ interface ApiEndpointDefinitions {
   }
   '/definitions/scenarios/:scenario_ids': {
     GET: ApiEndpoint<Empty, Empty, ScenarioDefinitionRow[]>
+  }
+  '/definitions/fields/:field_ids': {
+    GET: ApiEndpoint<Empty, Empty, FieldDefinitionRow[]>
   }
   '/submissions': {
     GET: ApiEndpoint<Empty, { benchmark_ids?: string; ids?: string; submitted_by?: string }, SubmissionRow[]>

--- a/ts/common/interfaces.ts
+++ b/ts/common/interfaces.ts
@@ -52,7 +52,7 @@ export interface Submission_old extends Resource<'/submissions/'> {
 
 export type AggFunction = 'SUM' | 'NANSUM' | 'MEAN' | 'NANMEAN' | 'MEADIAN' | 'NANMEDIAN'
 
-export interface FieldDefinitionRow extends Resource<'/fields/'> {
+export interface FieldDefinitionRow extends Resource<'/definitions/fields/'> {
   id: string
   /** Identifier of field, how it's accessed in aggregation. */
   key: string

--- a/ts/frontend/src/app/app.routes.ts
+++ b/ts/frontend/src/app/app.routes.ts
@@ -11,6 +11,7 @@ import { VcEvaluationObjectiveView } from './views/vc-evaluation-objective/vc-ev
 import { VcKpiView } from './views/vc-kpi/vc-kpi.view'
 import { VcMySubmissionsView } from './views/vc-my-submissions/vc-my-submissions.view'
 import { VcNewSubmissionView } from './views/vc-new-submission/vc-new-submission.view'
+import { VcResultsView } from './views/vc-results/vc-results.view'
 import { VcSubmissionView } from './views/vc-submission/vc-submission.view'
 
 export const routes: Routes = [
@@ -68,6 +69,11 @@ export const routes: Routes = [
   {
     path: 'submissions/:submission_id',
     component: VcSubmissionView,
+    canActivate: [AuthGuard],
+  },
+  {
+    path: 'submissions/:submission_id/results/:test_id/:scenario_id',
+    component: VcResultsView,
     canActivate: [AuthGuard],
   },
   { path: 'impressum', component: ImpressumView },

--- a/ts/frontend/src/app/components/table/table.component.html
+++ b/ts/frontend/src/app/components/table/table.component.html
@@ -18,6 +18,8 @@
               @if (cell.scorings) {
                 {{ cell.scorings['primary']?.score | number:'1.2-2' }}
               }
+            } @else if ('input' in cell) {
+              <input type="number" step="0.01" class="text-right shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" [ngModel]="cell.input.value" (ngModelChange)="cell.input.onChange($event)">
             }
           </td>
         }

--- a/ts/frontend/src/app/components/table/table.component.ts
+++ b/ts/frontend/src/app/components/table/table.component.ts
@@ -1,7 +1,18 @@
 import { CommonModule } from '@angular/common'
 import { Component, Input } from '@angular/core'
+import { FormsModule } from '@angular/forms'
 import { RouterModule } from '@angular/router'
 import { Scorings } from '@common/interfaces'
+
+/**
+ * Input in a cell.
+ */
+export interface TableInput {
+  /** (Initial) value to display. */
+  value: number | null
+  /** Callback invoked when the input field changes. */
+  onChange: (value: number) => void
+}
 
 /**
  * One column in a {@link TableComponent}.
@@ -23,11 +34,19 @@ export type TableCell =
       /** Text to display in the cell. */
       text: string | number | null
       scorings?: undefined
+      input?: undefined
     }
   | {
       text?: undefined
       /** Scorings to display in the cell. */
       scorings: Scorings | null
+      input?: undefined
+    }
+  | {
+      text?: undefined
+      scorings?: undefined
+      /** Input field to display in the cell. */
+      input: TableInput
     }
 
 /**
@@ -43,7 +62,7 @@ export interface TableRow {
 
 @Component({
   selector: 'app-table',
-  imports: [CommonModule, RouterModule],
+  imports: [CommonModule, FormsModule, RouterModule],
   templateUrl: './table.component.html',
   styleUrl: './table.component.scss',
 })

--- a/ts/frontend/src/app/views/vc-results/vc-results.view.html
+++ b/ts/frontend/src/app/views/vc-results/vc-results.view.html
@@ -1,0 +1,22 @@
+<app-breadcrumbs></app-breadcrumbs>
+
+<lib-content>
+  <app-site-heading class="bp-8 flex w-full" [title]="`Results for ${submission?.name}, ${scenario?.name}`" [logo]="customization?.content?.logo | publicResource"></app-site-heading>
+
+  <lib-section class="w-full">
+    <p>
+      {{ scenario?.description }}
+    </p>
+  </lib-section>
+</lib-content>
+
+<lib-content>
+  <app-table [columns]="columns" [rows]="rows" class="w-full"></app-table>
+</lib-content>
+
+@if (needsManualScoring()) {
+  <lib-content>
+    <p class="pb-8">Please fill in all fields and submit for manual scoring.</p>
+    <button class="bg-primary-500 hover:bg-primary-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline disabled:bg-primary-100" type="button" [attr.disabled]="canSubmitManualScoring() ? null : true" (click)="submitManualScoring()">Submit scoring</button>
+  </lib-content>
+}

--- a/ts/frontend/src/app/views/vc-results/vc-results.view.ts
+++ b/ts/frontend/src/app/views/vc-results/vc-results.view.ts
@@ -1,0 +1,154 @@
+import { Component, inject, OnInit } from '@angular/core'
+import { ActivatedRoute, RouterModule } from '@angular/router'
+import {
+  FieldDefinitionRow,
+  PostTestResultsBody,
+  ScenarioDefinitionRow,
+  ScenarioScored,
+  Scoring,
+  SubmissionRow,
+} from '@common/interfaces'
+import { ContentComponent, SectionComponent } from '@flatland-association/flatland-ui'
+import { BreadcrumbsComponent } from '../../components/breadcrumbs/breadcrumbs.component'
+import { SiteHeadingComponent } from '../../components/site-heading/site-heading.component'
+import { TableColumn, TableComponent, TableRow } from '../../components/table/table.component'
+import { ApiService } from '../../features/api/api.service'
+import { AuthService } from '../../features/auth/auth.service'
+import { Customization, CustomizationService } from '../../features/customization/customization.service'
+import { PublicResourcePipe } from '../../pipes/public-resource/public-resource.pipe'
+
+@Component({
+  selector: 'view-vc-results',
+  imports: [
+    RouterModule,
+    ContentComponent,
+    SectionComponent,
+    BreadcrumbsComponent,
+    PublicResourcePipe,
+    SiteHeadingComponent,
+    TableComponent,
+  ],
+  templateUrl: './vc-results.view.html',
+  styleUrl: './vc-results.view.scss',
+})
+export class VcResultsView implements OnInit {
+  apiService = inject(ApiService)
+  authService = inject(AuthService)
+  customizationService = inject(CustomizationService)
+
+  submissionId: string
+  testId: string
+  scenarioId: string
+  submission?: SubmissionRow
+  scenario?: ScenarioDefinitionRow
+  results?: ScenarioScored
+  fields?: FieldDefinitionRow[]
+  manualFields: string[] = []
+  customization?: Customization
+
+  ownSubmission = false
+
+  columns: TableColumn[] = [{ title: 'Field' }, { title: 'Description' }, { title: 'Score', align: 'right' }]
+  rows: TableRow[] = []
+
+  constructor() {
+    const route = inject(ActivatedRoute)
+
+    this.submissionId = route.snapshot.params['submission_id']
+    this.testId = route.snapshot.params['test_id']
+    this.scenarioId = route.snapshot.params['scenario_id']
+  }
+
+  async ngOnInit() {
+    this.customization = await this.customizationService.getCustomization()
+    this.submission = (
+      await this.apiService.get('/submissions/:submission_ids', { params: { submission_ids: this.submissionId } })
+    ).body?.at(0)
+    this.ownSubmission = this.submission?.submitted_by === this.authService.userUuid
+    this.scenario = (
+      await this.apiService.get('/definitions/scenarios/:scenario_ids', { params: { scenario_ids: this.scenarioId } })
+    ).body?.at(0)
+    this.results = (
+      await this.apiService.get('/results/submissions/:submission_id/scenario/:scenario_ids', {
+        params: { submission_id: this.submissionId, scenario_ids: this.scenarioId },
+      })
+    ).body?.at(0)
+    // load linked resources
+    // TODO: offload this to service with caching
+    const fieldIds = this.scenario?.field_ids
+    if (fieldIds) {
+      this.fields = (
+        await this.apiService.get('/definitions/fields/:field_ids', { params: { field_ids: fieldIds.join(',') } })
+      ).body
+    }
+    this.rebuildView()
+  }
+
+  rebuildView() {
+    // find out which fields need manual scoring
+    this.fields?.forEach((field) => {
+      const isScored = typeof this.results?.scorings[field.key]?.score === 'number'
+      if (!isScored) {
+        this.manualFields.push(field.key)
+      }
+    })
+    // build table
+    this.rows =
+      this.fields?.map((field) => {
+        // take existing scoring or prepare one for manual submission
+        const scoring: Scoring = this.results?.scorings[field.key] ?? { score: null }
+        const isScored = typeof scoring.score === 'number'
+        return {
+          cells: [
+            { text: field.key },
+            { text: field.description },
+            isScored
+              ? // when scored, show score as text (not formatted as scoring)
+                { text: scoring.score ?? null }
+              : //... otherwise, depending on submission owner
+                this.ownSubmission
+                ? // own submission: show input
+                  {
+                    input: {
+                      value: scoring.score,
+                      onChange: (value: number) => {
+                        scoring.score = value
+                      },
+                    },
+                  }
+                : // indicate unavailable score
+                  {
+                    text: 'NA',
+                  },
+          ],
+        }
+      }) ?? []
+  }
+
+  needsManualScoring() {
+    return this.manualFields.length > 0
+  }
+
+  canSubmitManualScoring() {
+    return this.manualFields.every((key) => typeof this.results?.scorings[key]?.score === 'number')
+  }
+
+  async submitManualScoring() {
+    // prepare body data object
+    //@ts-expect-error type
+    const results: PostTestResultsBody['data'][0] = {
+      scenario_id: this.scenarioId,
+    }
+    // append manual scores
+    this.manualFields.forEach((key) => {
+      results[key] = this.results?.scorings[key]?.score ?? 0
+    })
+    // submit
+    await this.apiService.post('/results/submissions/:submission_id/tests/:test_ids', {
+      params: { submission_id: this.submissionId, test_ids: this.testId },
+      body: { data: [results] },
+    })
+    // rebuild view with local data
+    this.rebuildView()
+  }
+}

--- a/ts/frontend/src/app/views/vc-submission/vc-submission.view.ts
+++ b/ts/frontend/src/app/views/vc-submission/vc-submission.view.ts
@@ -101,6 +101,7 @@ export class VcSubmissionView implements OnInit {
       //... and per scenario
       test.scenario_scorings.forEach((scenario) => {
         this.rows.push({
+          routerLink: ['results', test.test_id, scenario.scenario_id],
           cells: [
             { text: '' },
             { text: this.scenarios!.get(scenario.scenario_id)?.name ?? 'NA' },


### PR DESCRIPTION
## Changes

- Add input cell type to table
- Add field controller
- Add results detail view, allowing manual scoring

## Related issues

Closes #208 

## Request for Comment

* Risk:  low
* Discussion: low

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Prefix the commits with one of the labels of [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).
<!--
The Conventional Commits specification is a lightweight convention on top of commit messages. It provides an easy set of rules for creating an explicit commit history; which makes it easier to write automated tools on top of. This convention dovetails with SemVer, by describing the features, fixes, and breaking changes made in commit messages.

The commit message should be structured as follows:
  <type>[optional scope]: <description>
  
  [optional body]
  
  [optional footer(s)]


1. fix: a commit of the type fix patches a bug in your codebase (this correlates with PATCH in Semantic Versioning).
2. feat: a commit of the type feat introduces a new feature to the codebase (this correlates with MINOR in Semantic Versioning).
3. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.
4. types other than fix: and feat: are allowed, for example @commitlint/config-conventional (based on the Angular convention) recommends 
    - build:
    - chore:
    - ci:
    - docs:
    - style:
    - refactor:
    - perf:
    - test:
5. footers other than BREAKING CHANGE: <description> may be provided and follow a convention similar to git trailer format.
 
-->
- [ ] Document changes in this pull request above.
- [ ] Documentation is added in the `docs` folder for relevant behavior changes.
- [ ] Technical guidelines listed in `docs/CONTRIBUTING.md` are followed.
