### PR TITLE
refactor: Change json type declaration

### DIFF
--- a/ts/backend/src/app/features/services/aggregator-service.mts
+++ b/ts/backend/src/app/features/services/aggregator-service.mts
@@ -15,7 +15,6 @@ import {
   SubmissionTestScore,
   TestDefinitionRow,
 } from '@common/interfaces'
-import { json } from '@common/utility-types'
 import { configuration } from '../config/config.mjs'
 import { Logger } from '../logger/logger.mjs'
 import { Service } from './service.mjs'
@@ -215,7 +214,7 @@ export class AggregatorService extends Service {
       WHERE scenario_definitions.id = ANY(${scenarioIds})
     `
     if (this.sql.errors) {
-      logger.error(this.sql.errors as unknown as json)
+      logger.error(this.sql.errors)
     }
     return (
       sources ??
@@ -242,7 +241,7 @@ export class AggregatorService extends Service {
       WHERE test_definitions.id = ANY(${testIds})
     `
     if (this.sql.errors) {
-      logger.error(this.sql.errors as unknown as json)
+      logger.error(this.sql.errors)
     }
     return (
       sources ??
@@ -282,7 +281,7 @@ export class AggregatorService extends Service {
       WHERE submissions.id = ANY(${submissionIds})
     `
     if (this.sql.errors) {
-      logger.error(this.sql.errors as unknown as json)
+      logger.error(this.sql.errors)
     }
     return (
       sources ??
@@ -320,7 +319,7 @@ export class AggregatorService extends Service {
       WHERE benchmark_definitions.id = ANY(${benchmarkIds})
     `
     if (this.sql.errors) {
-      logger.error(this.sql.errors as unknown as json)
+      logger.error(this.sql.errors)
     }
     return (
       sources ??
@@ -358,7 +357,7 @@ export class AggregatorService extends Service {
       WHERE benchmark_definitions.id = ANY(${benchmarkIds})
     `
     if (this.sql.errors) {
-      logger.error(this.sql.errors as unknown as json)
+      logger.error(this.sql.errors)
     }
     return (
       sources ??
@@ -398,7 +397,7 @@ export class AggregatorService extends Service {
       WHERE benchmark_groups.id = ANY(${groupIds})
     `
     if (this.sql.errors) {
-      logger.error(this.sql.errors as unknown as json)
+      logger.error(this.sql.errors)
     }
     return (
       sources ??
@@ -423,7 +422,7 @@ export class AggregatorService extends Service {
   ): FieldDefinitionRow | undefined {
     const field = sources.field_definitions.find((fieldDefRow) => fieldDefRow?.id === fieldId)
     if (!field) {
-      logger.warn(`field ${fieldId} not found in sources`, sources.field_definitions as unknown as json)
+      logger.warn(`field ${fieldId} not found in sources`, sources.field_definitions)
     }
     return field ?? undefined
   }
@@ -437,7 +436,7 @@ export class AggregatorService extends Service {
   ): ScenarioDefinitionRow | undefined {
     const scenario = sources.scenario_definitions.find((scenarioDefRow) => scenarioDefRow?.id === scenarioId)
     if (!scenario) {
-      logger.warn(`scenario ${scenarioId} not found in sources`, sources.scenario_definitions as unknown as json)
+      logger.warn(`scenario ${scenarioId} not found in sources`, sources.scenario_definitions)
     }
     return scenario ?? undefined
   }
@@ -448,7 +447,7 @@ export class AggregatorService extends Service {
   findTest(sources: { test_definitions: (TestDefinitionRow | null)[] }, testId: string): TestDefinitionRow | undefined {
     const test = sources.test_definitions.find((testDefRow) => testDefRow?.id === testId)
     if (!test) {
-      logger.warn(`test ${testId} not found in sources`, sources.test_definitions as unknown as json)
+      logger.warn(`test ${testId} not found in sources`, sources.test_definitions)
     }
     return test ?? undefined
   }
@@ -459,7 +458,7 @@ export class AggregatorService extends Service {
   findSubmission(sources: { submissions: (SubmissionRow | null)[] }, submissionId: string): SubmissionRow | undefined {
     const submission = sources.submissions.find((submission) => submission?.id === submissionId)
     if (!submission) {
-      logger.warn(`submission ${submissionId} not found in sources`, sources.submissions as unknown as json)
+      logger.warn(`submission ${submissionId} not found in sources`, sources.submissions)
     }
     return submission ?? undefined
   }
@@ -473,7 +472,7 @@ export class AggregatorService extends Service {
   ): BenchmarkDefinitionRow | undefined {
     const benchmark = sources.benchmark_definitions.find((benchmarkDefRow) => benchmarkDefRow?.id === benchmarkId)
     if (!benchmark) {
-      logger.warn(`benchmark ${benchmarkId} not found in sources`, sources.benchmark_definitions as unknown as json)
+      logger.warn(`benchmark ${benchmarkId} not found in sources`, sources.benchmark_definitions)
     }
     return benchmark ?? undefined
   }
@@ -487,7 +486,7 @@ export class AggregatorService extends Service {
   ): BenchmarkGroupDefinitionRow | undefined {
     const group = sources.benchmark_groups.find((groupDefRow) => groupDefRow?.id === groupId)
     if (!group) {
-      logger.warn(`group ${groupId} not found in sources`, sources.benchmark_groups as unknown as json)
+      logger.warn(`group ${groupId} not found in sources`, sources.benchmark_groups)
     }
     return group ?? undefined
   }
@@ -502,10 +501,7 @@ export class AggregatorService extends Service {
   ): FieldDefinitionRow | undefined {
     const primary = sources.field_definitions.find((fieldDefRow) => fieldDefRow?.id === entity.field_ids[0])
     if (!primary) {
-      logger.warn(
-        `field ${entity.field_ids[0]} (primary score) not found in sources`,
-        sources.field_definitions as unknown as json,
-      )
+      logger.warn(`field ${entity.field_ids[0]} (primary score) not found in sources`, sources.field_definitions)
     }
     return primary ?? undefined
   }

--- a/ts/common/utility-types.ts
+++ b/ts/common/utility-types.ts
@@ -45,7 +45,7 @@ export type NotUnion<T, U = T> = U extends T ? ([T] extends [U] ? T : never) : n
  * Data type for values that can be serialized and deserialized using
  * `JSON.stringify` and `JSON.parse`.
  */
-export type json = boolean | number | string | null | undefined | { [key: string]: json } | json[]
+export type json = boolean | number | string | object | null | undefined
 
 /**
  * Coerces given type to accept `string | number` where it initially only


### PR DESCRIPTION
## Changes

Added `object` to `json` union, now accepting objects of named interfaces where previously they had to be annotated `as json` manually before.

## Related issues

Closes #274 

## Request for Comment

* Risk: low - the type declaration was widened, but it's not possible to break anything with that
* Discussion: low

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Prefix the commits with one of the labels of [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).
<!--
The Conventional Commits specification is a lightweight convention on top of commit messages. It provides an easy set of rules for creating an explicit commit history; which makes it easier to write automated tools on top of. This convention dovetails with SemVer, by describing the features, fixes, and breaking changes made in commit messages.

The commit message should be structured as follows:
  <type>[optional scope]: <description>
  
  [optional body]
  
  [optional footer(s)]


1. fix: a commit of the type fix patches a bug in your codebase (this correlates with PATCH in Semantic Versioning).
2. feat: a commit of the type feat introduces a new feature to the codebase (this correlates with MINOR in Semantic Versioning).
3. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.
4. types other than fix: and feat: are allowed, for example @commitlint/config-conventional (based on the Angular convention) recommends 
    - build:
    - chore:
    - ci:
    - docs:
    - style:
    - refactor:
    - perf:
    - test:
5. footers other than BREAKING CHANGE: <description> may be provided and follow a convention similar to git trailer format.
 
-->
- [ ] Document changes in this pull request above.
- [ ] Documentation is added in the `docs` folder for relevant behavior changes.
- [ ] Technical guidelines listed in `docs/CONTRIBUTING.md` are followed.
