### PR TITLE
ci: include spec files in type check

### DIFF
--- a/ts/backend/eslint.config.js
+++ b/ts/backend/eslint.config.js
@@ -5,5 +5,12 @@ const tseslint = require("typescript-eslint");
 const rootConfig = require("../../eslint.config.js");
 
 module.exports = tseslint.config(
-  ...rootConfig
+  ...rootConfig,
+  // Per default, **/*.js, **/*.cjs, and **/*.mjs are always matched unless
+  // globally ignored. Thus, globally ignore coverage, where auto-generated .js
+  // files live:
+  // https://eslint.org/docs/latest/use/configure/configuration-files#:~:text=By%20default%2C%20ESLint%20lints%20files%20that%20match%20the%20patterns%20**/*.js%2C%20**/*.cjs%2C%20and%20**/*.mjs.%20Those%20files%20are%20always%20matched%20unless%20you%20explicitly%20exclude%20them%20using%20global%20ignores.
+  {
+    ignores: ['test/coverage/**']
+  }
 );

--- a/ts/backend/package.json
+++ b/ts/backend/package.json
@@ -6,7 +6,7 @@
     "start.fab": "CUSTOMIZATION=fab npm run private:start",
     "start.ai4realnet": "CUSTOMIZATION=ai4realnet npm run private:start",
     "build": "npm run private:swagger:prod && npm run private:build && mkdir -p ../../dist/backend/config && mkdir -p ../../dist/backend/public && mkdir -p ../../dist/backend/app && cp ../../out-tsc/backend/main.min.mjs ../../dist/backend/app",
-    "check": "npm run private:swagger:prod && tsc -p tsconfig.check.json && npx eslint",
+    "check": "npm run private:swagger:prod && tsc -p tsconfig.check.json && tsc -p test/integration/tsconfig.check.json && npx eslint",
     "test": "vitest run --coverage",
     "private:start": "concurrently --kill-others 'npm run private:serve' 'npm run private:test'",
     "private:serve": "npm run private:swagger:dev && npm run private:build && cd ../../out-tsc && mkdir -p backend-serve/app && cp backend/main.min.mjs backend-serve/app && mkdir -p backend-serve/config && cp -n ../ts/backend/src/config/config.jsonc \"$_\" && rm -rf backend-serve/public && cp -rf ../ts/backend/src/public.${CUSTOMIZATION} backend-serve/public && cd backend-serve/app && node main.min.mjs --help --log-level=ALL --log-colorful --log-stringify",

--- a/ts/backend/test/integration/benchmark.controller.spec.ts
+++ b/ts/backend/test/integration/benchmark.controller.spec.ts
@@ -10,6 +10,8 @@ const protoBenchmark = [
     name: 'Benchmark 1',
     description: 'Domain X benchmark',
     field_ids: ['be7bf55a-9d79-4e89-8509-f8d2af9b3fad', 'f6b23ac8-2f12-4e77-8de4-4939b818ca8e'],
+    // TOFIX: https://github.com/flatland-association/flatland-benchmarks/issues/364
+    campaign_field_ids: undefined as unknown as [],
     test_ids: ['557d9a00-7e6d-410b-9bca-a017ca7fe3aa'],
   },
 ] satisfies ApiGetEndpoints['/definitions/benchmarks']['response']['body']

--- a/ts/backend/test/integration/test.controller.spec.ts
+++ b/ts/backend/test/integration/test.controller.spec.ts
@@ -12,7 +12,9 @@ describe.sequential('Test controller', () => {
   })
 
   test('should return test by id', async () => {
-    const res = await controller.testGet('/definitions/tests/:test_ids', { params: { ids: '1' } })
+    const res = await controller.testGet('/definitions/tests/:test_ids', {
+      params: { test_ids: 'aeabd5b9-4e86-4c7a-859f-a32ff1be5516' },
+    })
     expect(res.status).toBe(200)
     expect(res.body).toBeApiResponse()
   })

--- a/ts/backend/test/integration/tsconfig.check.json
+++ b/ts/backend/test/integration/tsconfig.check.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  }
+}

--- a/ts/backend/tsconfig.check.json
+++ b/ts/backend/tsconfig.check.json
@@ -5,5 +5,6 @@ exact reason why it breaks is unclear to me. OS */
   "compilerOptions": {
     "noEmit": true
   },
-  "files": ["./src/app/main.mts"]
+  "files": ["./src/app/main.mts"],
+  "include": ["./src/**/*.spec.ts"]
 }


### PR DESCRIPTION
## Changes

Included `.spec.ts` and other test files in checks (tsc type checking and eslint).

## Related issues

Closes #362 

## Request for Comment

* Risk: low
* Discussion: low

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Prefix the commits with one of the labels of [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).
<!--
The Conventional Commits specification is a lightweight convention on top of commit messages. It provides an easy set of rules for creating an explicit commit history; which makes it easier to write automated tools on top of. This convention dovetails with SemVer, by describing the features, fixes, and breaking changes made in commit messages.

The commit message should be structured as follows:
  <type>[optional scope]: <description>
  
  [optional body]
  
  [optional footer(s)]


1. fix: a commit of the type fix patches a bug in your codebase (this correlates with PATCH in Semantic Versioning).
2. feat: a commit of the type feat introduces a new feature to the codebase (this correlates with MINOR in Semantic Versioning).
3. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.
4. types other than fix: and feat: are allowed, for example @commitlint/config-conventional (based on the Angular convention) recommends 
    - build:
    - chore:
    - ci:
    - docs:
    - style:
    - refactor:
    - perf:
    - test:
5. footers other than BREAKING CHANGE: <description> may be provided and follow a convention similar to git trailer format.
 
-->
- [ ] Document changes in this pull request above.
- [ ] Documentation is added in the `docs` folder for relevant behavior changes.
- [ ] Technical guidelines listed in `docs/CONTRIBUTING.md` are followed.
