### PR TITLE
fix(backend): Logger: preserve error messages

### DIFF
--- a/ts/backend/src/app/features/controller/controller.mts
+++ b/ts/backend/src/app/features/controller/controller.mts
@@ -66,7 +66,7 @@ export class Controller {
       body: body,
       dbg,
     })
-    logger.debug(`${req.method} ${req.originalUrl} response 200: ${JSON.stringify(body)}`)
+    logger.debug(`${req.method} ${req.originalUrl}: Response ${status}`, body)
   }
 
   /**
@@ -84,7 +84,7 @@ export class Controller {
       error,
       dbg,
     })
-    logger.warn(`${req.method} ${req.originalUrl}: Bad request 400: ${JSON.stringify(error)}`)
+    logger.warn(`${req.method} ${req.originalUrl}: Bad request 400`, error)
   }
 
   /**
@@ -102,7 +102,7 @@ export class Controller {
       error,
       dbg,
     })
-    logger.warn(`${req.method} ${req.originalUrl}: Unauthorized 401: ${JSON.stringify(error)}`)
+    logger.warn(`${req.method} ${req.originalUrl}: Unauthorized 401`, error)
   }
 
   /**
@@ -120,7 +120,7 @@ export class Controller {
       error,
       dbg,
     })
-    logger.error(`${req.method} ${req.originalUrl}: Server error 500: ${JSON.stringify(error)}`)
+    logger.error(`${req.method} ${req.originalUrl}: Internal server error 500`, error)
   }
 
   // Attach handler wrapper, serves two purposes:
@@ -134,16 +134,16 @@ export class Controller {
   ) {
     this.router[verb](endpoint, async (req, res, next) => {
       try {
-        logger.debug(`${req.method} ${req.originalUrl} received: ${JSON.stringify(req.body)}`)
+        logger.debug(`${req.method} ${req.originalUrl}: Request`, req.body)
         await handler(req, res, next)
         // force a server error if the handler did not respond
         if (!res.writableEnded) {
+          logger.error(`${req.method} ${req.originalUrl}: Handler did not respond.`)
           next('Handler did not respond')
-          logger.error(`${req.method} ${req.originalUrl}: handler did not respond.`)
         }
       } catch (error) {
+        logger.error(`${req.method} ${req.originalUrl}: Exception`, error)
         next(error)
-        logger.error(`${req.method} ${req.originalUrl} error: ${JSON.stringify(error)}`)
       }
     })
   }


### PR DESCRIPTION
## Changes

- Change data type of log message argument (accept basically anything)
- Change object logging in controller as-is
- Fix uncaught exception when errors occur after headers sent

## Related issues

Closes #366 Closes #354 Closes #355 

## Request for Comment

* Risk: low
* Discussion: low

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Prefix the commits with one of the labels of [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).
<!--
The Conventional Commits specification is a lightweight convention on top of commit messages. It provides an easy set of rules for creating an explicit commit history; which makes it easier to write automated tools on top of. This convention dovetails with SemVer, by describing the features, fixes, and breaking changes made in commit messages.

The commit message should be structured as follows:
  <type>[optional scope]: <description>
  
  [optional body]
  
  [optional footer(s)]


1. fix: a commit of the type fix patches a bug in your codebase (this correlates with PATCH in Semantic Versioning).
2. feat: a commit of the type feat introduces a new feature to the codebase (this correlates with MINOR in Semantic Versioning).
3. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.
4. types other than fix: and feat: are allowed, for example @commitlint/config-conventional (based on the Angular convention) recommends 
    - build:
    - chore:
    - ci:
    - docs:
    - style:
    - refactor:
    - perf:
    - test:
5. footers other than BREAKING CHANGE: <description> may be provided and follow a convention similar to git trailer format.
 
-->
- [ ] Document changes in this pull request above.
- [ ] Documentation is added in the `docs` folder for relevant behavior changes.
- [ ] Technical guidelines listed in `docs/CONTRIBUTING.md` are followed.
