### PR TITLE
feat(frontend): Start login flow on 401 response

### DIFF
--- a/ts/frontend/public/silent-refresh.html
+++ b/ts/frontend/public/silent-refresh.html
@@ -1,0 +1,7 @@
+<html>
+<body>
+  <script>
+    (window.opener || window.parent).postMessage(location.hash || ('#' + location.search), location.origin);
+  </script>
+</body>
+</html>

--- a/ts/frontend/src/app/app.config.ts
+++ b/ts/frontend/src/app/app.config.ts
@@ -1,12 +1,14 @@
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http'
-import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core'
+import { ApplicationConfig, ErrorHandler, provideZoneChangeDetection } from '@angular/core'
 import { provideRouter } from '@angular/router'
 import { routes } from './app.routes'
+import { ErrorHandlerService } from './features/error-handler/error-handler.service'
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes),
     provideHttpClient(withInterceptorsFromDi()),
+    { provide: ErrorHandler, useClass: ErrorHandlerService },
   ],
 }

--- a/ts/frontend/src/app/features/auth/auth.service.ts
+++ b/ts/frontend/src/app/features/auth/auth.service.ts
@@ -77,8 +77,9 @@ export class AuthService {
    * @param state State passed around during login, used as redirect url on success.
    */
   logIn(state?: string) {
+    const keycloakTab = window.open('about:blank', 'keycloakTab')!
     this.oauthService
-      .initLoginFlowInPopup({ width: 500, height: 590 })
+      .initImplicitFlowInPopup({ windowRef: keycloakTab })
       .then(() => {
         if (state && state !== '/') {
           this.router.navigate([state])

--- a/ts/frontend/src/app/features/auth/auth.service.ts
+++ b/ts/frontend/src/app/features/auth/auth.service.ts
@@ -77,7 +77,16 @@ export class AuthService {
    * @param state State passed around during login, used as redirect url on success.
    */
   logIn(state?: string) {
-    this.oauthService.initLoginFlow(state)
+    this.oauthService
+      .initLoginFlowInPopup({ width: 500, height: 590 })
+      .then(() => {
+        if (state && state !== '/') {
+          this.router.navigate([state])
+        }
+      })
+      .catch(() => {
+        // presence of handler required, although no action is taken
+      })
   }
 
   /**

--- a/ts/frontend/src/app/features/error-handler/error-handler.service.spec.ts
+++ b/ts/frontend/src/app/features/error-handler/error-handler.service.spec.ts
@@ -1,0 +1,33 @@
+import { TestBed } from '@angular/core/testing'
+
+import { HttpErrorResponse } from '@angular/common/http'
+import { AuthService } from '../auth/auth.service'
+import { ErrorHandlerService } from './error-handler.service'
+
+describe('ErrorHandlerService', () => {
+  let service: ErrorHandlerService
+  let authServiceSpy: jasmine.SpyObj<AuthService>
+
+  beforeEach(() => {
+    authServiceSpy = jasmine.createSpyObj('AuthService', ['logIn'])
+
+    TestBed.configureTestingModule({
+      providers: [{ provide: AuthService, useValue: authServiceSpy }],
+    })
+    service = TestBed.inject(ErrorHandlerService)
+  })
+
+  it('should catch and handle HttpErrorResponse errors', () => {
+    expect(() => service.handleError(new HttpErrorResponse({}))).not.toThrow()
+  })
+
+  it('should start login on HttpErrorResponse status 401', () => {
+    expect(() => service.handleError(new HttpErrorResponse({ status: 401 }))).not.toThrow()
+    expect(authServiceSpy.logIn).toHaveBeenCalled()
+  })
+
+  it('should pass through other errors', () => {
+    const error = new Error()
+    expect(() => service.handleError(error)).toThrow(error)
+  })
+})

--- a/ts/frontend/src/app/features/error-handler/error-handler.service.ts
+++ b/ts/frontend/src/app/features/error-handler/error-handler.service.ts
@@ -1,0 +1,29 @@
+import { HttpErrorResponse } from '@angular/common/http'
+import { ErrorHandler, inject, Injectable } from '@angular/core'
+import { AuthService } from '../auth/auth.service'
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ErrorHandlerService implements ErrorHandler {
+  private authService = inject(AuthService)
+
+  handleError(error: unknown): void {
+    // Not using an HttpInterceptor for http error handling to have finer
+    // control of when this global handler takes effect. I.e. it will only be
+    // invoked if an HttpErrorResponse was not handled by another `.catch`,
+    // making it the default behavior, which can be simply overridden by
+    // providing a custom handler where the request is being made.
+    if (error instanceof HttpErrorResponse) {
+      console.warn('Globally handling HttpErrorResponse', error)
+      if (error.status === 401) {
+        this.authService.logIn()
+      } else {
+        console.error(`No global handler for status ${error.status} defined`)
+      }
+      return
+    }
+    // the super global error handler prints unhandled exceptions to the console
+    throw error
+  }
+}

--- a/ts/frontend/src/environments/environment.development.ts
+++ b/ts/frontend/src/environments/environment.development.ts
@@ -11,6 +11,7 @@ const authConfig: AuthConfig = {
   // redirectUri: location.origin + location.pathname.substring(0, location.pathname.indexOf('/', 1) + 1)
   // Note that these URIs must also be added to allowed redirect URIs in Azure (e.g. https://your-domain/en/, https://your-domain/de/, ...)
   redirectUri: location.origin,
+  silentRefreshRedirectUri: window.location.origin + '/silent-refresh.html',
   responseType: 'code',
   scope: 'openid profile email offline_access',
 }

--- a/ts/frontend/src/environments/environment.ts
+++ b/ts/frontend/src/environments/environment.ts
@@ -9,6 +9,7 @@ const authConfig: AuthConfig = {
   // redirectUri: location.origin + location.pathname.substring(0, location.pathname.indexOf('/', 1) + 1)
   // Note that these URIs must also be added to allowed redirect URIs in Azure (e.g. https://your-domain/en/, https://your-domain/de/, ...)
   redirectUri: location.origin,
+  silentRefreshRedirectUri: window.location.origin + '/silent-refresh.html',
   responseType: 'code',
   scope: 'openid profile email offline_access',
 }


### PR DESCRIPTION
## Changes

- Changed login flow to use new tab
- Add global error handler to start login flow on 401

## Related issues

Closes #267

## Request for Comment

* Risk: low
* Discussion: low

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Prefix the commits with one of the labels of [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).
<!--
The Conventional Commits specification is a lightweight convention on top of commit messages. It provides an easy set of rules for creating an explicit commit history; which makes it easier to write automated tools on top of. This convention dovetails with SemVer, by describing the features, fixes, and breaking changes made in commit messages.

The commit message should be structured as follows:
  <type>[optional scope]: <description>
  
  [optional body]
  
  [optional footer(s)]


1. fix: a commit of the type fix patches a bug in your codebase (this correlates with PATCH in Semantic Versioning).
2. feat: a commit of the type feat introduces a new feature to the codebase (this correlates with MINOR in Semantic Versioning).
3. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.
4. types other than fix: and feat: are allowed, for example @commitlint/config-conventional (based on the Angular convention) recommends 
    - build:
    - chore:
    - ci:
    - docs:
    - style:
    - refactor:
    - perf:
    - test:
5. footers other than BREAKING CHANGE: <description> may be provided and follow a convention similar to git trailer format.
 
-->
- [ ] Document changes in this pull request above.
- [ ] Documentation is added in the `docs` folder for relevant behavior changes.
- [ ] Technical guidelines listed in `docs/CONTRIBUTING.md` are followed.
