### PR TITLE
fix(frontend): Table not showing primary scorings

### DIFF
--- a/ts/frontend/src/app/components/table/table.component.html
+++ b/ts/frontend/src/app/components/table/table.component.html
@@ -15,9 +15,7 @@
             @if ('text' in cell) {
               {{ cell.text }}
             } @else if ('scorings' in cell) {
-              @if (cell.scorings) {
-                {{ cell.scorings['primary']?.score | number:'1.2-2' }}
-              }
+              {{ getPrimaryScoring(cell)?.score | number:'1.2-2' }}
             } @else if ('input' in cell) {
               <input type="number" step="0.01" class="text-right shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" [ngModel]="cell.input.value" (ngModelChange)="cell.input.onChange($event)">
             }

--- a/ts/frontend/src/app/components/table/table.component.ts
+++ b/ts/frontend/src/app/components/table/table.component.ts
@@ -2,7 +2,7 @@ import { CommonModule } from '@angular/common'
 import { Component, Input } from '@angular/core'
 import { FormsModule } from '@angular/forms'
 import { RouterModule } from '@angular/router'
-import { Scorings } from '@common/interfaces'
+import { FieldDefinitionRow, Scorings } from '@common/interfaces'
 
 /**
  * Input in a cell.
@@ -34,17 +34,24 @@ export type TableCell =
       /** Text to display in the cell. */
       text: string | number | null
       scorings?: undefined
+      fieldDefinitions?: undefined
       input?: undefined
     }
   | {
       text?: undefined
       /** Scorings to display in the cell. */
       scorings: Scorings | null
+      /**
+       * Meta data (field definitions) of Scorings to display. Optional, default
+       * is to display `primary`.
+       */
+      fieldDefinitions?: (FieldDefinitionRow | undefined)[]
       input?: undefined
     }
   | {
       text?: undefined
       scorings?: undefined
+      fieldDefinitions?: undefined
       /** Input field to display in the cell. */
       input: TableInput
     }
@@ -72,4 +79,9 @@ export class TableComponent {
 
   @Input()
   rows: TableRow[] = []
+
+  getPrimaryScoring(cell: TableCell) {
+    const primaryKey = cell.fieldDefinitions?.at(0)?.key ?? 'primary'
+    return cell.scorings?.[primaryKey]
+  }
 }

--- a/ts/frontend/src/app/views/my-submissions/my-submissions.view.ts
+++ b/ts/frontend/src/app/views/my-submissions/my-submissions.view.ts
@@ -65,7 +65,7 @@ export class MySubmissionsView implements OnInit {
     this.rows =
       this.submissions?.map((submission) => {
         return {
-          routerLink: ['/', 'vc-evaluation-objective', submission.test_ids[0], 'my-submissions'],
+          routerLink: ['/', 'vc-evaluation-objective', submission.benchmark_id, 'my-submissions'],
           cells: [
             { text: submission.name },
             { text: this.benchmarks?.get(submission.benchmark_id)?.name ?? 'NA' },


### PR DESCRIPTION
## Changes

- Fixed tables not displaying score when primary score is not named `primary`

## Related issues

<!--
Link to every issue from the issue tracker (if any) you addressed in this PR.
See [here](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) on how to use keywords to automatically close the issue when someone merges the pull request
-->

## Request for Comment

* Risk: <!-- [low/mid/high] -->
* Discussion: <!-- [low/mid/high] -->

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Prefix the commits with one of the labels of [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).
<!--
The Conventional Commits specification is a lightweight convention on top of commit messages. It provides an easy set of rules for creating an explicit commit history; which makes it easier to write automated tools on top of. This convention dovetails with SemVer, by describing the features, fixes, and breaking changes made in commit messages.

The commit message should be structured as follows:
  <type>[optional scope]: <description>
  
  [optional body]
  
  [optional footer(s)]


1. fix: a commit of the type fix patches a bug in your codebase (this correlates with PATCH in Semantic Versioning).
2. feat: a commit of the type feat introduces a new feature to the codebase (this correlates with MINOR in Semantic Versioning).
3. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.
4. types other than fix: and feat: are allowed, for example @commitlint/config-conventional (based on the Angular convention) recommends 
    - build:
    - chore:
    - ci:
    - docs:
    - style:
    - refactor:
    - perf:
    - test:
5. footers other than BREAKING CHANGE: <description> may be provided and follow a convention similar to git trailer format.
 
-->
- [ ] Document changes in this pull request above.
- [ ] Documentation is added in the `docs` folder for relevant behavior changes.
- [ ] Technical guidelines listed in `docs/CONTRIBUTING.md` are followed.
