### PR TITLE
fix(backend): allow only `Admin`s to `POST` submission status not their own.

### DIFF
--- a/ts/backend/src/app/features/controller/submission.controller.mts
+++ b/ts/backend/src/app/features/controller/submission.controller.mts
@@ -33,8 +33,6 @@ export class SubmissionController extends Controller {
     this.attachGet('/submissions/all', this.getAllSubmissions, { authorizedRoles: ['Admin'] })
     this.attachGet('/submissions/:submission_ids', this.getSubmissionByUuid)
     this.attachPatch('/submissions/:submission_ids', this.patchSubmissionByUuid, { authorizedRoles: ['User'] })
-    // TODO: only authorize orchestrator
-    // https://github.com/flatland-association/flatland-benchmarks/issues/484
     this.attachPost('/submissions/:submission_ids/statuses', this.postSubmissionStatus, { authorizedRoles: ['User'] })
     this.attachGet('/submissions/:submission_ids/statuses', this.getStubmissionStatuses)
   }
@@ -868,7 +866,9 @@ export class SubmissionController extends Controller {
    *                          timestamp:
    *                            type: string
    */
-  postSubmissionStatus: PostHandler<'/submissions/:submission_ids/statuses'> = async (req, res) => {
+  postSubmissionStatus: PostHandler<'/submissions/:submission_ids/statuses'> = async (req, res, _next, _auth) => {
+    const auth = _auth!
+    const authService = AuthService.getInstance()
     const uuids = req.params.submission_ids.split(',')
     const status = req.body.status
     const message = req.body?.message
@@ -882,6 +882,19 @@ export class SubmissionController extends Controller {
     `
     if (submissionMismatches.length) {
       throw new ControllerError('Referenced submission does not exist', submissionMismatches, StatusCodes.BAD_REQUEST)
+    }
+    // unless Admin, assert User only posts status to own submissions
+    if (!authService.authorization(req, auth, ['Admin'])) {
+      const ownershipMismatches = await sql.query`
+        SELECT reference
+        FROM UNNEST(${uuids}::uuid[]) AS reference
+               LEFT JOIN submissions ON id = reference
+        WHERE submitted_by IS DISTINCT
+        FROM ${auth.sub}
+      `
+      if (ownershipMismatches.length) {
+        throw new ControllerError('Cannot update submission', ownershipMismatches, StatusCodes.FORBIDDEN)
+      }
     }
     const statusInserts = uuids.map((uuid) => {
       return {

--- a/ts/backend/test/integration/results.controller.spec.ts
+++ b/ts/backend/test/integration/results.controller.spec.ts
@@ -152,6 +152,76 @@ describe.sequential('Results controller', () => {
     expect(res.body.body.at(0)?.test_scorings[0].scenario_scorings[2].scorings[1].score).toBeNull()
   })
 
+  test('should return slimmed benchmark leaderboard for user in competition setting', async () => {
+    const res = await controller.testGet(
+      '/results/benchmarks/:benchmark_ids',
+      {
+        params: {
+          benchmark_ids: 'c85d5fc2-15da-4a62-8e14-28d1261c29bd',
+        },
+      },
+      testUserJwt,
+    )
+    assertApiResponse(res, 200)
+    expect(res.body.body).toHaveLength(1)
+    res.body.body.at(0)?.items.forEach((item) => {
+      expect(item.test_scorings).toHaveLength(0)
+    })
+  })
+
+  test('should return full benchmark leaderboard for admin despite competition setting', async () => {
+    const res = await controller.testGet(
+      '/results/benchmarks/:benchmark_ids',
+      {
+        params: {
+          benchmark_ids: 'c85d5fc2-15da-4a62-8e14-28d1261c29bd',
+        },
+      },
+      testAdminJwt,
+    )
+    assertApiResponse(res, 200)
+    expect(res.body.body).toHaveLength(1)
+    res.body.body.at(0)?.items.forEach((item) => {
+      expect(item.test_scorings.length).toBeGreaterThan(0)
+    })
+  })
+
+  test('should return slimmed test leaderboard for user in competition setting', async () => {
+    const res = await controller.testGet(
+      '/results/benchmarks/:benchmark_id/tests/:test_ids',
+      {
+        params: {
+          benchmark_id: 'c85d5fc2-15da-4a62-8e14-28d1261c29bd',
+          test_ids: '39ae35d8-4b0f-467f-9ec4-ee19c3558c7f',
+        },
+      },
+      testUserJwt,
+    )
+    assertApiResponse(res, 200)
+    expect(res.body.body).toHaveLength(1)
+    res.body.body.at(0)?.items.forEach((item) => {
+      expect(item.test_scorings).toHaveLength(0)
+    })
+  })
+
+  test('should return full test leaderboard for admin despite competition setting', async () => {
+    const res = await controller.testGet(
+      '/results/benchmarks/:benchmark_id/tests/:test_ids',
+      {
+        params: {
+          benchmark_id: 'c85d5fc2-15da-4a62-8e14-28d1261c29bd',
+          test_ids: '39ae35d8-4b0f-467f-9ec4-ee19c3558c7f',
+        },
+      },
+      testAdminJwt,
+    )
+    assertApiResponse(res, 200)
+    expect(res.body.body).toHaveLength(1)
+    res.body.body.at(0)?.items.forEach((item) => {
+      expect(item.test_scorings.length).toBeGreaterThan(0)
+    })
+  })
+
   // Benchmark leaderboard does not make valid sense with campaign test data,
   // but for testing purposes (checking if the aggregator returns consistent
   // values), probing this leaderboard is good enough.

--- a/ts/backend/test/integration/submission.controller.spec.ts
+++ b/ts/backend/test/integration/submission.controller.spec.ts
@@ -371,6 +371,34 @@ describe.sequential('Submission controller', () => {
     assertApiResponse(res, StatusCodes.UNAUTHORIZED)
   })
 
+  test('should deny posting status to another user submission', async ({ skip }) => {
+    if (!submissionUuid) skip()
+    const res = await controller.testPost(
+      `/submissions/:submission_ids/statuses`,
+      {
+        params: { submission_ids: submissionUuid },
+        body: { status: 'STARTED', message: 'hijack attempt' },
+      },
+      testOtherUserJwt,
+    )
+    assertApiResponse(res, StatusCodes.FORBIDDEN)
+  })
+
+  test('should allow admin to post status to any submission', async ({ skip }) => {
+    if (!submissionUuid) skip()
+    const res = await controller.testPost(
+      `/submissions/:submission_ids/statuses`,
+      {
+        params: { submission_ids: submissionUuid },
+        body: { status: 'STARTED', message: 'admin override' },
+      },
+      testAdminJwt,
+    )
+    assertApiResponse(res)
+    expect(res.body.body).toHaveLength(1)
+    expect(res.body.body.at(0)?.status).toBe('STARTED')
+  })
+
   test('should allow updating submission status', async ({ skip }) => {
     if (!submissionUuid) skip()
     const res = await controller.testPost(

--- a/ts/backend/test/integration/submission.controller.spec.ts
+++ b/ts/backend/test/integration/submission.controller.spec.ts
@@ -387,7 +387,7 @@ describe.sequential('Submission controller', () => {
   test('should allow admin to post status to any submission', async ({ skip }) => {
     const submission = await controller.testPost('/submissions', { body: testSubmission }, testUserJwt)
     assertApiResponse(submission)
-    submissionUuid = submission.body.body.id
+    const submissionUuid = submission.body.body.id
 
     const res = await controller.testPost(
       `/submissions/:submission_ids/statuses`,

--- a/ts/backend/test/integration/submission.controller.spec.ts
+++ b/ts/backend/test/integration/submission.controller.spec.ts
@@ -385,7 +385,10 @@ describe.sequential('Submission controller', () => {
   })
 
   test('should allow admin to post status to any submission', async ({ skip }) => {
-    if (!submissionUuid) skip()
+    const submission = await controller.testPost('/submissions', { body: testSubmission }, testUserJwt)
+    assertApiResponse(submission)
+    submissionUuid = submission.body.body.id
+
     const res = await controller.testPost(
       `/submissions/:submission_ids/statuses`,
       {

--- a/ts/backend/test/integration/submission.controller.spec.ts
+++ b/ts/backend/test/integration/submission.controller.spec.ts
@@ -334,6 +334,14 @@ describe.sequential('Submission controller', () => {
     assertApiResponse(res)
   })
 
+  test('should not prevent posting skip_enqueue submissions if admin even if daily limit 0', async () => {
+    const testConfig = await getTestConfig()
+    testConfig.submissions = { global: { dailyLimit: 0 } }
+    controller = new ControllerTestAdapter(SubmissionController, testConfig)
+    const res = await controller.testPost('/submissions/skip_enqueue', { body: testSubmission }, testAdminJwt)
+    assertApiResponse(res)
+  })
+
   test('should not prevent submissions if daily limit null', async () => {
     const testConfig = await getTestConfig()
     testConfig.submissions = { global: { dailyLimit: null } }
@@ -348,6 +356,19 @@ describe.sequential('Submission controller', () => {
     controller = new ControllerTestAdapter(SubmissionController, testConfig)
     const res = await controller.testPost('/submissions', { body: testSubmission }, testUserJwt)
     assertApiResponse(res)
+  })
+
+  test('should deny unauthenticated access to POST submission status', async ({ skip }) => {
+    if (!submissionUuid) skip()
+    const res = await controller.testPost(
+      `/submissions/:submission_ids/statuses`,
+      {
+        params: { submission_ids: submissionUuid },
+        body: { status: 'STARTED', message: 'unauthorized attempt' },
+      },
+      null,
+    )
+    assertApiResponse(res, StatusCodes.UNAUTHORIZED)
   })
 
   test('should allow updating submission status', async ({ skip }) => {


### PR DESCRIPTION
## Changes
* test(backend): increase test coverage
* fix(backend): allow only admin to POST status to non-own submissions.
<!-- Describe the changes you made. -->

## Related issues
Follow-up to https://github.com/flatland-association/flatland-benchmarks/pull/524
Relates to #484 


<!--
Link to every issue from the issue tracker (if any) you addressed in this PR.
See [here](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) on how to use keywords to automatically close the issue when someone merges the pull request
-->

## Request for Comment

* Risk: <!-- [low/mid/high] -->
* Discussion: <!-- [low/mid/high] -->

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Prefix the commits with one of the labels of [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).
<!--
The Conventional Commits specification is a lightweight convention on top of commit messages. It provides an easy set of rules for creating an explicit commit history; which makes it easier to write automated tools on top of. This convention dovetails with SemVer, by describing the features, fixes, and breaking changes made in commit messages.

The commit message should be structured as follows:
  <type>[optional scope]: <description>
  
  [optional body]
  
  [optional footer(s)]


1. fix: a commit of the type fix patches a bug in your codebase (this correlates with PATCH in Semantic Versioning).
2. feat: a commit of the type feat introduces a new feature to the codebase (this correlates with MINOR in Semantic Versioning).
3. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.
4. types other than fix: and feat: are allowed, for example @commitlint/config-conventional (based on the Angular convention) recommends 
    - build:
    - chore:
    - ci:
    - docs:
    - style:
    - refactor:
    - perf:
    - test:
5. footers other than BREAKING CHANGE: <description> may be provided and follow a convention similar to git trailer format.
 
-->
- [ ] Document changes in this pull request above.
- [ ] Documentation is added in the `docs` folder for relevant behavior changes.
- [ ] Technical guidelines listed in `docs/CONTRIBUTING.md` are followed.
