### PR TITLE
feat(backend): convert timestamps to UTC.

### DIFF
--- a/ts/backend/src/app/features/services/sql-service.mts
+++ b/ts/backend/src/app/features/services/sql-service.mts
@@ -120,6 +120,7 @@ export class SqlService extends Service implements WrappedSql<postgres.Sql> {
       password: this.config.postgres.password,
       database: this.config.postgres.database,
       debug: true, // otherwise errors will be empty object
+      connection: { TimeZone: 'UTC' },
       // default onnotice console.logs, overwrite that to push to notices
       // notices is emptied upon query()
       onnotice: (notice) => {

--- a/ts/backend/src/migration/schema/V20__use_utc_timestamps.sql
+++ b/ts/backend/src/migration/schema/V20__use_utc_timestamps.sql
@@ -14,10 +14,3 @@ ALTER
 COLUMN "timestamp" TYPE TIMESTAMPTZ
   USING "timestamp" AT TIME ZONE current_setting('TIMEZONE');
 
-ALTER TABLE results
-ALTER
-COLUMN created_at TYPE TIMESTAMPTZ
-  USING created_at AT TIME ZONE current_setting('TIMEZONE'),
-  ALTER
-COLUMN done_at TYPE TIMESTAMPTZ
-  USING done_at AT TIME ZONE current_setting('TIMEZONE');

--- a/ts/backend/src/migration/schema/V20__use_utc_timestamps.sql
+++ b/ts/backend/src/migration/schema/V20__use_utc_timestamps.sql
@@ -1,0 +1,23 @@
+-- `timestamp without time zone AT TIME ZONE zone` interprets the bare value as being in `zone`
+-- and returns a `timestamptz` (PostgreSQL stores timestamptz internally as UTC).
+-- Example: '14:00:00' AT TIME ZONE 'Europe/Zurich' → 13:00:00+00 (UTC)
+-- Example: '14:00:00' AT TIME ZONE 'UTC'            → 14:00:00+00 (value unchanged, type changes)
+-- Requirement: current_setting('TIMEZONE') must match the timezone active when rows were written.
+
+ALTER TABLE submissions
+ALTER
+COLUMN submitted_at TYPE TIMESTAMPTZ
+  USING submitted_at AT TIME ZONE current_setting('TIMEZONE');
+
+ALTER TABLE submission_statuses
+ALTER
+COLUMN "timestamp" TYPE TIMESTAMPTZ
+  USING "timestamp" AT TIME ZONE current_setting('TIMEZONE');
+
+ALTER TABLE results
+ALTER
+COLUMN created_at TYPE TIMESTAMPTZ
+  USING created_at AT TIME ZONE current_setting('TIMEZONE'),
+  ALTER
+COLUMN done_at TYPE TIMESTAMPTZ
+  USING done_at AT TIME ZONE current_setting('TIMEZONE');

--- a/ts/backend/test/integration/submission.controller.utc.spec.ts
+++ b/ts/backend/test/integration/submission.controller.utc.spec.ts
@@ -1,0 +1,95 @@
+import { beforeAll, describe, expect, test } from 'vitest'
+import { SubmissionController } from '../../src/app/features/controller/submission.controller.mjs'
+import {
+  assertApiResponse,
+  ControllerTestAdapter,
+  setupControllerTestEnvironment,
+  testAdminJwt,
+} from '../controller.test-adapter.mjs'
+import { getTestConfig } from './setup.mjs'
+// Seed data UUIDs inserted by V3.1__new_demo_data.sql / V3.2__new_demo_submission.sql
+const BENCHMARK_ID = '20ccc7c1-034c-4880-8946-bffc3fed1359'
+const TEST_ID = '557d9a00-7e6d-410b-9bca-a017ca7fe3aa'
+
+let adapter: ControllerTestAdapter
+
+beforeAll(async () => {
+  const config = await getTestConfig()
+  setupControllerTestEnvironment(config)
+  adapter = new ControllerTestAdapter(SubmissionController, config)
+})
+
+describe('SubmissionController – UTC timestamps', () => {
+  test('submitted_at is returned as a UTC ISO string', async () => {
+    const before = new Date()
+    const post = await adapter.testPost(
+      '/submissions/skip_enqueue',
+      {
+        body: {
+          benchmark_id: BENCHMARK_ID,
+          test_ids: [TEST_ID],
+          name: 'utc-test-submitted-at',
+          submission_data_url: 'http://example.com/submission',
+        },
+      },
+      testAdminJwt,
+    )
+    const after = new Date()
+    assertApiResponse(post)
+
+    const submissionId = post.body.body!.id
+    const get = await adapter.testGet(
+      '/submissions/:submission_ids',
+      { params: { submission_ids: submissionId } },
+      testAdminJwt,
+    )
+    assertApiResponse(get)
+    const submission = get.body.body![0]
+
+    // Timestamp must be a UTC ISO string (Z suffix) regardless of the DB session timezone.
+    // With a `timestamp without time zone` column this would fail in non-UTC server environments.
+    expect(submission.submitted_at).toMatch(/Z$/)
+    const submittedAt = new Date(submission.submitted_at!)
+    expect(submittedAt.getTime()).toBeGreaterThanOrEqual(before.getTime())
+    expect(submittedAt.getTime()).toBeLessThanOrEqual(after.getTime() + 1000)
+  })
+
+  test('submission status timestamp is returned as a UTC ISO string', async () => {
+    // Create a submission to attach statuses to
+    const post = await adapter.testPost(
+      '/submissions/skip_enqueue',
+      {
+        body: {
+          benchmark_id: BENCHMARK_ID,
+          test_ids: [TEST_ID],
+          name: 'utc-test-status',
+          submission_data_url: 'http://example.com/submission',
+        },
+      },
+      testAdminJwt,
+    )
+    assertApiResponse(post)
+    const submissionId = post.body.body!.id
+
+    // Post a status update and capture the returned statuses
+    const before = new Date()
+    const postStatus = await adapter.testPost(
+      '/submissions/:submission_ids/statuses',
+      {
+        params: { submission_ids: submissionId },
+        body: { status: 'STARTED', message: null },
+      },
+      testAdminJwt,
+    )
+    const after = new Date()
+    assertApiResponse(postStatus)
+
+    // Verify every returned status timestamp is a UTC ISO string
+    for (const status of postStatus.body.body!) {
+      expect(status.timestamp).toMatch(/Z$/)
+      const ts = new Date(status.timestamp)
+      expect(ts.getTime()).toBeGreaterThanOrEqual(before.getTime())
+      expect(ts.getTime()).toBeLessThanOrEqual(after.getTime() + 1000)
+    }
+  })
+})


### PR DESCRIPTION
## Changes

timetsamp in DB are stored withtout tz but with CET offset added -> old timestamp are not updated correctly by this pr, but new timestamps are entered correctly.
<!-- Describe the changes you made. -->

## Related issues
Follow-up to #606 and https://github.com/flatland-association/flatland-benchmarks/pull/645

<!--
Link to every issue from the issue tracker (if any) you addressed in this PR.
See [here](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) on how to use keywords to automatically close the issue when someone merges the pull request
-->

## Request for Comment

* Risk: <!-- [low/mid/high] -->
* Discussion: <!-- [low/mid/high] -->

## Checklist

- [ ] Tests are included for relevant behavior changes.
- [ ] Prefix the commits with one of the labels of [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).
<!--
The Conventional Commits specification is a lightweight convention on top of commit messages. It provides an easy set of rules for creating an explicit commit history; which makes it easier to write automated tools on top of. This convention dovetails with SemVer, by describing the features, fixes, and breaking changes made in commit messages.

The commit message should be structured as follows:
  <type>[optional scope]: <description>
  
  [optional body]
  
  [optional footer(s)]


1. fix: a commit of the type fix patches a bug in your codebase (this correlates with PATCH in Semantic Versioning).
2. feat: a commit of the type feat introduces a new feature to the codebase (this correlates with MINOR in Semantic Versioning).
3. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.
4. types other than fix: and feat: are allowed, for example @commitlint/config-conventional (based on the Angular convention) recommends 
    - build:
    - chore:
    - ci:
    - docs:
    - style:
    - refactor:
    - perf:
    - test:
5. footers other than BREAKING CHANGE: <description> may be provided and follow a convention similar to git trailer format.
 
-->
- [ ] Document changes in this pull request above.
- [ ] Documentation is added in the `docs` folder for relevant behavior changes.
- [ ] Technical guidelines listed in `docs/CONTRIBUTING.md` are followed.
